### PR TITLE
Print QNetworkReply::NetworkError code to logs

### DIFF
--- a/GPClient/gpclient.cpp
+++ b/GPClient/gpclient.cpp
@@ -74,8 +74,9 @@ void GPClient::on_connectButton_clicked()
 
 void GPClient::preloginResultFinished()
 {
-    if (reply->error()) {
-        qWarning() << "Prelogin request error";
+    QNetworkReply::NetworkError err = reply->error();
+    if (err) {
+        qWarning() << "Prelogin request error: " << err;
         emit connectFailed();
         return;
     }


### PR DESCRIPTION
As an aid to debugging, print out the prelogin error code from QT's network manager. This helped me see that I was hitting an SSL handshake error for instance.