### PR TITLE
Fix for Bug with KDE and Qt 5.11

### DIFF
--- a/GPClient/gpclient.cpp
+++ b/GPClient/gpclient.cpp
@@ -51,13 +51,13 @@ void GPClient::on_connectButton_clicked()
 {
     QString btnText = ui->connectButton->text();
 
-    if (btnText == "Connect") {
+    if (btnText.endsWith("Connect")) {
         QString portal = ui->portalInput->text();
         settings->setValue("portal", portal);
         ui->statusLabel->setText("Authenticating...");
         updateConnectionStatus("pending");
         doAuth(portal);
-    } else if (btnText == "Cancel") {
+    } else if (btnText.endsWith("Cancel")) {
         ui->statusLabel->setText("Canceling...");
         updateConnectionStatus("pending");
 


### PR DESCRIPTION
If the application is build with Qt 5.11 (standard on debian 10) and it is executed in the Desktop Environment KDE the text of the connectButton is (for some reasons) "&Connect".
So connecting to VPN is not possible (immediately jumps to disconnect).
This pull request should fix this issue.