### PR TITLE
added startupwmclass to desktop file

### DIFF
--- a/GPClient/com.yuezk.qt.gpclient.desktop
+++ b/GPClient/com.yuezk.qt.gpclient.desktop
@@ -8,3 +8,4 @@ Exec=/usr/bin/gpclient
 Icon=com.yuezk.qt.GPClient
 Categories=Network;VPN;Utility;Qt;
 Keywords=GlobalProtect;Openconnect;SAML;connection;VPN;
+StartupWMClass=gpclient


### PR DESCRIPTION
This quick edit allows the application to be detected by desktop environments. In my case, I set the client as a favorite in gnome, and when clicking on it another icon appeared. With this edit, another icon does not appear - it just highlights the existing favorite icon.