### PR TITLE
Mark for inclusion in aarch64 archlinux repository

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -5,7 +5,7 @@ _gitname=GlobalProtect-openconnect
 pkgver={PKG_VERSION}
 pkgrel=1
 pkgdesc="A GlobalProtect VPN client (GUI) for Linux based on Openconnect and built with Qt5, supports SAML auth mode."
-arch=(x86_64)
+arch=(x86_64 aarch64)
 url="https://github.com/yuezk/${_gitname}"
 license=('GPL3')
 depends=('openconnect>=8.0.0' qt5-base qt5-webengine qt5-websockets)


### PR DESCRIPTION
Hey, today I tested the current head of the repository on a Pinebook Pro with the official Manjaro aarch64/KDE image. As far as I can tell, it fully works. I can establish a connection, I receive the correct routes and DNS settings. ICMP and TCP is working and the connection is stable.

With this change, I hope to have the archlinux/Manjaro package available also for the aarch64 architecture which includes the Pinebook series as well as the Raspberry Pi 4+.

(Thanks for the development on this project!)