### PR TITLE
Remove qt5 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,27 @@ A GlobalProtect VPN client (GUI) for Linux based on Openconnect and built with Q
 ### Ubuntu
 1. Install openconnect v8.x
 
+    ```sh
+    sudo apt install openconnect
+    openconnect --version
+    ```
+
    For Ubuntu 18.04 you might need to [build the latest openconnect from source code](https://gist.github.com/yuezk/ab9a4b87a9fa0182bdb2df41fab5f613).
    
 2. Install the Qt dependencies
+
+    For Ubuntu 20, this should work.
+    
     ```sh
-    sudo apt install qt5-default libqt5websockets5-dev qtwebengine5-dev qttools5-dev
+    sudo apt install  libqt5websockets5-dev qtwebengine5-dev qttools5-dev debhelper
     ```
+    
+    For Ubuntu 21, you need to install the base pieces separately as QT5 is the default.
+    
+    ```sh
+    sudo apt install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5websockets5-dev qtwebengine5-dev qttools5-dev debhelper
+    ```
+    
 ### OpenSUSE
 Install the Qt dependencies
 
@@ -76,13 +91,14 @@ Relatively manual process for now:
   git-archive-all --force-submodules --prefix=globalprotect-openconnect-1.3.0/ ../globalprotect-openconnect_1.3.0.orig.tar.gz
   ```
 
-* Finally extract the source tree and build the debian package.
+* Finally extract the source tree, build the debian package, and install it.
 
   ```
   cd ..
   tar -xzvf globalprotect-openconnect_1.3.0.orig.tar.gz
   cd globalprotect-openconnect-1.3.0
   fakeroot dpkg-buildpackage -uc -us -sa 2>&1 | tee ../build.log
+  sudo dpkg -i globalprotect-openconnect_1.3.0-1ppa1_amd64.deb
   ```
 
 ### NixOS

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A GlobalProtect VPN client (GUI) for Linux based on Openconnect and built with Q
     For Ubuntu 20, this should work.
     
     ```sh
-    sudo apt install  libqt5websockets5-dev qtwebengine5-dev qttools5-dev debhelper
+    sudo apt install qtbase5-dev libqt5websockets5-dev qtwebengine5-dev qttools5-dev debhelper
     ```
     
     For Ubuntu 21, you need to install the base pieces separately as QT5 is the default.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: globalprotect-openconnect
 Section: net
 Priority: optional
 Maintainer: Kevin Yue <k3vinyue@gmail.com>
-Build-Depends: debhelper (>=11~), qt5-default (>=5.9), qttools5-dev (>=5.9), libqt5websockets5-dev (>=5.9), qtwebengine5-dev (>=5.9)
+Build-Depends: debhelper (>=11~), qtbase5-dev, qttools5-dev (>=5.9), libqt5websockets5-dev (>=5.9), qtwebengine5-dev (>=5.9)
 Standards-Version: 4.1.4
 Homepage: https://github.com/yuezk/GlobalProtect-openconnect
 


### PR DESCRIPTION
QT5 is now the default in Ubuntu 21.04, and therefore there is a missing package.

I removed it from the debian/control file, and updated the README instructions.

I tested it on my own system, and it worked.

Addresses #67 