### PR TITLE
Add a scripting mode to GPClient

### DIFF
--- a/GPClient/CMakeLists.txt
+++ b/GPClient/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(gpclient
     gpclient.ui
     normalloginwindow.ui
     settingsdialog.ui
+    vpn_dbus.cpp
+    vpn_json.cpp
     resources.qrc
     ${gpclient_GENERATED_SOURCES}
 )
@@ -52,7 +54,7 @@ add_3rdparty(
 add_3rdparty(
     plog
     GIT_REPOSITORY https://github.com/SergiusTheBest/plog.git
-    GIT_TAG 1.1.5
+    GIT_TAG master
     CMAKE_ARGS
         -DPLOG_BUILD_SAMPLES=OFF
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/GPClient/gpclient.h
+++ b/GPClient/gpclient.h
@@ -6,9 +6,9 @@
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QPushButton>
 
-#include "gpserviceinterface.h"
 #include "portalconfigresponse.h"
 #include "settingsdialog.h"
+#include "vpn.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class GPClient; }
@@ -19,11 +19,19 @@ class GPClient : public QMainWindow
     Q_OBJECT
 
 public:
-    GPClient(QWidget *parent = nullptr);
+    GPClient(QWidget *parent, IVpn *vpn);
     ~GPClient();
 
     void activate();
     void quit();
+
+    QString portal() const;
+    void portal(QString);
+
+    GPGateway currentGateway() const;
+    void setCurrentGateway(const GPGateway gateway);
+
+    void doConnect();
 
 private slots:
     void onSettingsButtonClicked();
@@ -58,7 +66,7 @@ private:
     };
 
     Ui::GPClient *ui;
-    com::yuezk::qt::GPService *vpn;
+    IVpn *vpn;
 
     QSystemTrayIcon *systemTrayIcon;
     QMenu *contextMenu;
@@ -83,19 +91,14 @@ private:
     void populateGatewayMenu();
     void updateConnectionStatus(const VpnStatus &status);
 
-    void doConnect();
     void portalLogin();
     void tryGatewayLogin();
     void gatewayLogin();
 
-    QString portal() const;
     bool connected() const;
 
     QList<GPGateway> allGateways() const;
     void setAllGateways(QList<GPGateway> gateways);
-
-    GPGateway currentGateway() const;
-    void setCurrentGateway(const GPGateway gateway);
 
     void clearSettings();
 };

--- a/GPClient/vpn.h
+++ b/GPClient/vpn.h
@@ -1,0 +1,24 @@
+#ifndef VPN_H
+#define VPN_H
+#include <QtCore/QObject>
+#include <QtCore/QString>
+
+class IVpn
+{
+public:
+    virtual ~IVpn() = default;
+
+    virtual void connect(const QString &preferredServer, const QList<QString> &servers, const QString &username, const QString &passwd, const QString &extraArgs) = 0;
+    virtual void disconnect() = 0;
+    virtual int status() = 0;
+
+// signals: // SIGNALS
+//     virtual void connected();
+//     virtual void disconnected();
+//     virtual void error(const QString &errorMessage);
+//     virtual void logAvailable(const QString &log);
+};
+
+Q_DECLARE_INTERFACE(IVpn, "IVpn") // define this out of namespace scope
+
+#endif

--- a/GPClient/vpn_dbus.cpp
+++ b/GPClient/vpn_dbus.cpp
@@ -1,0 +1,13 @@
+#include "vpn_dbus.h"
+
+void VpnDbus::connect(const QString &preferredServer, const QList<QString> &servers, const QString &username, const QString &passwd, const QString &extraArgs) {
+    inner->connect(preferredServer, username, passwd, extraArgs);
+}
+
+void VpnDbus::disconnect() {
+    inner->disconnect();
+}
+
+int VpnDbus::status() {
+    return inner->status();
+}

--- a/GPClient/vpn_dbus.h
+++ b/GPClient/vpn_dbus.h
@@ -1,0 +1,33 @@
+#ifndef VPN_DBUS_H
+#define VPN_DBUS_H
+#include "vpn.h"
+#include "gpserviceinterface.h"
+
+class VpnDbus : public QObject, public IVpn
+{
+  Q_OBJECT
+  Q_INTERFACES(IVpn)
+
+private:
+  com::yuezk::qt::GPService *inner;
+
+public:
+  VpnDbus(QObject *parent) : QObject(parent) {
+    inner = new com::yuezk::qt::GPService("com.yuezk.qt.GPService", "/", QDBusConnection::systemBus(), this);
+    QObject::connect(inner, &com::yuezk::qt::GPService::connected, this, &VpnDbus::connected);
+    QObject::connect(inner, &com::yuezk::qt::GPService::disconnected, this, &VpnDbus::disconnected);
+    QObject::connect(inner, &com::yuezk::qt::GPService::error, this, &VpnDbus::error);
+    QObject::connect(inner, &com::yuezk::qt::GPService::logAvailable, this, &VpnDbus::logAvailable);
+  }
+
+  void connect(const QString &preferredServer, const QList<QString> &servers, const QString &username, const QString &passwd, const QString &extraArgs);
+  void disconnect();
+  int status();
+
+signals: // SIGNALS
+  void connected();
+  void disconnected();
+  void error(const QString &errorMessage);
+  void logAvailable(const QString &log);
+};
+#endif

--- a/GPClient/vpn_json.cpp
+++ b/GPClient/vpn_json.cpp
@@ -1,0 +1,24 @@
+#include "vpn_json.h"
+#include <QTextStream> 
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+void VpnJson::connect(const QString &preferredServer, const QList<QString> &servers, const QString &username, const QString &passwd, const QString &extraArgs) {
+    QJsonArray sl;
+    for (const QString &srv : servers) {
+      sl.push_back(QJsonValue(srv));
+    }
+    QJsonObject j;
+    j["server"] = preferredServer;
+    j["availableServers"] = sl;
+    j["cookie"] = passwd;
+    QTextStream(stdout) << QJsonDocument(j).toJson(QJsonDocument::Compact) << "\n";
+    emit connected();
+}
+
+void VpnJson::disconnect() { /* nop */ }
+
+int VpnJson::status() {
+    return 4; // disconnected
+}

--- a/GPClient/vpn_json.h
+++ b/GPClient/vpn_json.h
@@ -1,0 +1,23 @@
+#ifndef VPN_JSON_H
+#define VPN_JSON_H
+#include "vpn.h"
+
+class VpnJson : public QObject, public IVpn
+{
+  Q_OBJECT
+  Q_INTERFACES(IVpn)
+
+public:
+  VpnJson(QObject *parent) : QObject(parent) {}
+
+  void connect(const QString &preferredServer, const QList<QString> &servers, const QString &username, const QString &passwd, const QString &extraArgs);
+  void disconnect();
+  int status();
+
+signals: // SIGNALS
+  void connected();
+  void disconnected();
+  void error(const QString &errorMessage);
+  void logAvailable(const QString &log);
+};
+#endif


### PR DESCRIPTION
See `gpclient --help`. In this mode, GPClient outputs the cookie and
some extra information as a JSON file instead of contacting GPService
via DBUS. This allows external commands to implement their own method
of starting openconnect as root.