### PR TITLE
Fix gpservice after openconnect v8.20

### DIFF
--- a/GPService/gpservice.cpp
+++ b/GPService/gpservice.cpp
@@ -181,7 +181,7 @@ void GPService::onProcessStdout()
     QString output = openconnect->readAllStandardOutput();
 
     log(output);
-    if (output.indexOf("Connected as") >= 0) {
+    if (output.indexOf("Connected as") >= 0 || output.indexOf("Configured as") >= 0) {
         vpnStatus = GPService::VpnConnected;
         emit connected();
     }


### PR DESCRIPTION
GlobalProtect-openconnect is no longer able to detect openconnect connected status after v8.20 version.

openconnect v8.10 and older will send log "Connected as ..." after successfully connected, and gpservice looks for that string. After openconnect 8.20 the log changes to "Configured as ...".