### PR TITLE
Clear SSL_OP_LEGACY_SERVER_CONNECT

### DIFF
--- a/GPClient/gphelper.cpp
+++ b/GPClient/gphelper.cpp
@@ -19,6 +19,7 @@ QNetworkReply* gpclient::helper::createRequest(QString url, QByteArray params)
     // Skip the ssl verifying
     QSslConfiguration conf = request.sslConfiguration();
     conf.setPeerVerifyMode(QSslSocket::VerifyNone);
+    conf.setSslOption(QSsl::SslOptionDisableLegacyRenegotiation, false);
     request.setSslConfiguration(conf);
 
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");


### PR DESCRIPTION
openssl enables (disables legacy renegotiation) by default since recent
versions. PA backend still requires it to function. Until it's fixed
with the vendor, it should be enabled (disable-flag cleared).

Ref: https://github.com/openssl/openssl/commit/72d2670bd21becfa6a64bb03fa55ad82d6d0c0f3