### PR TITLE
handle html comment for saml result with okta 2fa

### DIFF
--- a/GPClient/samlloginwindow.h
+++ b/GPClient/samlloginwindow.h
@@ -20,10 +20,15 @@ public:
 signals:
     void success(QMap<QString, QString> samlResult);
     void fail(const QString msg);
+    void getHTML(QString sHTML);
+
+protected slots:
+    void handleHTML(QString sHTML);
 
 private slots:
     void onResponseReceived(QJsonObject params);
     void onLoadFinished();
+    void checkSamlResult(QString username, QString preloginCookie, QString userAuthCookie);
 
 private:
     EnhancedWebView *webView;


### PR DESCRIPTION
I've never written any QT code so I am sure this requires some care and I went a very fast route of using regex to parse html comments. It seems to work fine but may require some code love. Still opening the PR for review and for others to try it out. While this solves the problem for okta 2fa(& hopefully does not cause any regression), I think this may just be a general approach for the cases where saml content come in html body when the ACS url is hit after authentication succeeds with the identity provider.

closes #152 