### PR TITLE
Add spanish (es) and Portuguese (pt) support to change status when connected to vpn

### DIFF
--- a/GPService/gpservice.cpp
+++ b/GPService/gpservice.cpp
@@ -199,7 +199,9 @@ void GPService::onProcessStdout()
     QString output = openconnect->readAllStandardOutput();
 
     log(output);
-    if (output.indexOf("Connected as") >= 0 || output.indexOf("Configured as") >= 0) {
+    if (output.indexOf("Connected as") >= 0 ||
+        output.indexOf("Configured as") >= 0 ||
+        output.indexOf("Configurado como") >= 0) {
         vpnStatus = GPService::VpnConnected;
         emit connected();
     }


### PR DESCRIPTION
When SO isn't set up in English, when the Client connects to the VPN it doesn't change the status to "Connected" and icon doesn't look `active`. 
 
https://github.com/yuezk/GlobalProtect-openconnect/issues/150#issuecomment-1155221171

Based on @yuezk  answer I added support for Spanish as well as Portuguese

https://github.com/yuezk/GlobalProtect-openconnect/issues/150#issuecomment-1158417534

I build and test locally with success

![image](https://user-images.githubusercontent.com/4960589/174503659-685fc2b3-b25b-461a-a256-3eb2463c6760.png)
