### PR TITLE
Credentials autocompleting (secure version)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "plog"]
 	path = 3rdparty/plog
 	url = https://github.com/SergiusTheBest/plog.git
+[submodule "3rdparty/qtkeychain"]
+	path = 3rdparty/qtkeychain
+	url = git@github.com:frankosterfeld/qtkeychain.git

--- a/GPClient/CMakeLists.txt
+++ b/GPClient/CMakeLists.txt
@@ -64,6 +64,17 @@ add_3rdparty(
         -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
 )
 
+add_3rdparty(
+    qtkeychain
+    GIT_REPOSITORY https://github.com/frankosterfeld/qtkeychain.git
+    GIT_TAG master
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+        -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
+        -DCMAKE_PREFIX_PATH=$ENV{CMAKE_PREFIX_PATH}
+)
+
 ExternalProject_Get_Property(SingleApplication-${PROJECT_NAME} SOURCE_DIR BINARY_DIR)
 set(SingleApplication_INCLUDE_DIR ${SOURCE_DIR})
 set(SingleApplication_LIBRARY ${BINARY_DIR}/libSingleApplication.a)
@@ -71,7 +82,12 @@ set(SingleApplication_LIBRARY ${BINARY_DIR}/libSingleApplication.a)
 ExternalProject_Get_Property(plog-${PROJECT_NAME} SOURCE_DIR)
 set(plog_INCLUDE_DIR "${SOURCE_DIR}/include")
 
-add_dependencies(gpclient SingleApplication-${PROJECT_NAME} plog-${PROJECT_NAME})
+ExternalProject_Get_Property(qtkeychain-${PROJECT_NAME} SOURCE_DIR BINARY_DIR)
+set(qtkeychain_INCLUDE_DIR "${SOURCE_DIR}")
+set(qtkeychain_BINARY_DIR "${BINARY_DIR}")
+set(qtkeychain_LIBRARY ${BINARY_DIR}/libqt5keychain.so)
+
+add_dependencies(gpclient SingleApplication-${PROJECT_NAME} plog-${PROJECT_NAME} qtkeychain-${PROJECT_NAME})
 
 target_include_directories(gpclient PRIVATE
     ${CMAKE_BINARY_DIR}
@@ -79,10 +95,13 @@ target_include_directories(gpclient PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${SingleApplication_INCLUDE_DIR}
     ${plog_INCLUDE_DIR}
+    ${qtkeychain_INCLUDE_DIR}
+    ${qtkeychain_BINARY_DIR}
 )
 
 target_link_libraries(gpclient
     ${SingleApplication_LIBRARY}
+    ${qtkeychain_LIBRARY}
     Qt5::Widgets
     Qt5::Network
     Qt5::WebSockets

--- a/GPClient/gphelper.cpp
+++ b/GPClient/gphelper.cpp
@@ -9,8 +9,11 @@
 #include <plog/Log.h>
 #include <QWebEngineProfile>
 #include <QWebEngineCookieStore>
+#include <keychain.h>
 
 #include "gphelper.h"
+
+using namespace QKeychain;
 
 QNetworkAccessManager* gpclient::helper::networkManager = new QNetworkAccessManager;
 
@@ -131,4 +134,39 @@ void gpclient::helper::settings::clear()
     }
 
     QWebEngineProfile::defaultProfile()->cookieStore()->deleteAllCookies();
+}
+
+
+bool gpclient::helper::settings::secureSave(const QString &key, const QString &value) {
+    WritePasswordJob job( QLatin1String("gpclient") );
+    job.setAutoDelete( false );
+    job.setKey( key );
+    job.setTextData( value );
+    QEventLoop loop;
+    job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+    job.start();
+    loop.exec();
+    if ( job.error() ) {
+        return false;
+    }
+
+    return true;
+}
+
+bool gpclient::helper::settings::secureGet(const QString &key, QString &value) {
+    ReadPasswordJob job( QLatin1String("gpclient") );
+    job.setAutoDelete( false );
+    job.setKey( key );
+    QEventLoop loop;
+    job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+    job.start();
+    loop.exec();
+
+    const QString pw = job.textData();
+    if ( job.error() ) {
+        return false;
+    }
+    
+    value = pw;
+    return true;
 }

--- a/GPClient/gphelper.h
+++ b/GPClient/gphelper.h
@@ -36,6 +36,9 @@ namespace gpclient {
             QVariant get(const QString &key, const QVariant &defaultValue = QVariant());
             void save(const QString &key, const QVariant &value);
             void clear();
+
+            bool secureSave(const QString &key, const QString &value);
+            bool secureGet(const QString &key, QString &value);
         }
     }
 }

--- a/GPClient/standardloginwindow.cpp
+++ b/GPClient/standardloginwindow.cpp
@@ -2,6 +2,9 @@
 
 #include "standardloginwindow.h"
 #include "ui_standardloginwindow.h"
+#include "gphelper.h"
+
+using namespace gpclient::helper;
 
 StandardLoginWindow::StandardLoginWindow(const QString &portalAddress, const QString &labelUsername,
                                          const QString &labelPassword, const QString &authMessage) :
@@ -13,9 +16,22 @@ StandardLoginWindow::StandardLoginWindow(const QString &portalAddress, const QSt
     ui->password->setPlaceholderText(labelPassword);
     ui->authMessage->setText(authMessage);
 
+    autocomplete();
+
     setWindowTitle("GlobalProtect Login");
     setFixedSize(width(), height());
     setModal(true);
+}
+
+void StandardLoginWindow::autocomplete() {
+    QString username, password;
+    settings::secureGet("username", username);
+    settings::secureGet("password", password);
+
+    if (!username.isEmpty() && !password.isEmpty()) {
+        ui->username->setText(username);
+        ui->password->setText(password);
+    }
 }
 
 void StandardLoginWindow::setProcessing(bool isProcessing) {
@@ -31,6 +47,9 @@ void StandardLoginWindow::on_loginButton_clicked() {
     if (username.isEmpty() || password.isEmpty()) {
         return;
     }
+
+    settings::secureSave("username", username);
+    settings::secureSave("password", password);
 
     emit performLogin(username, password);
 }

--- a/GPClient/standardloginwindow.h
+++ b/GPClient/standardloginwindow.h
@@ -28,6 +28,7 @@ private:
     Ui::StandardLoginWindow *ui;
 
     void closeEvent(QCloseEvent *event);
+    void autocomplete();
 };
 
 #endif // STANDARDLOGINWINDOW_H

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -6,6 +6,7 @@ sudo apt-get install -y \
     qtbase5-dev \
     libqt5websockets5-dev \
     qtwebengine5-dev \
+	qttools5-dev \
     openconnect
 
 ./scripts/install.sh


### PR DESCRIPTION
See #109 

I've successfully integrated https://github.com/frankosterfeld/qtkeychain/ as @yuezk suggested.

Added two methods in the `settings` namespace:
```c++
bool secureSave(const QString &key, const QString &value);
bool secureGet(const QString &key, QString &value);
````

Credentials are saved when the login button is clicked in the `StandardLoginWindow`, and autocompleted when the same window is created. Maybe there is a better way to manage this, I'll leave it to the ones that have a deeper knowledge of the project (Perhaps we could try to log in without showing that window if the credentials are present in the wallet).

Disclaimer: only tested on Manjaro KDE