### PR TITLE
copy install script for debian

### DIFF
--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -1,0 +1,1 @@
+install-ubuntu.sh

--- a/scripts/install-debian.sh
+++ b/scripts/install-debian.sh
@@ -1,1 +1,11 @@
-install-ubuntu.sh
+#!/bin/bash -e
+
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    qtbase5-dev \
+    libqt5websockets5-dev \
+    qtwebengine5-dev \
+    openconnect
+
+./scripts/install.sh


### PR DESCRIPTION
Weeks ago I sought to install this on Debian, tried to follow the build instructions, couldn't find which packages represented the various qt dependencies, and gave up.
This time it took me 90 seconds, because I looked at the ubuntu install for clues and found that the ubuntu install works just fine on Debian Bullseye.