### PR TITLE
Fixing binary paths array wrongly iterated up to binaryPaths->length()

### DIFF
--- a/GPService/gpservice.cpp
+++ b/GPService/gpservice.cpp
@@ -34,9 +34,9 @@ GPService::~GPService()
 
 QString GPService::findBinary()
 {
-    for (int i = 0; i < binaryPaths->length(); i++) {
-        if (QFileInfo::exists(binaryPaths[i])) {
-            return binaryPaths[i];
+    for (auto& binaryPath : binaryPaths) {
+        if (QFileInfo::exists(binaryPath)) {
+            return binaryPath;
         }
     }
     return nullptr;

--- a/GPService/gpservice.h
+++ b/GPService/gpservice.h
@@ -4,14 +4,13 @@
 #include <QtCore/QObject>
 #include <QtCore/QProcess>
 
-static const QString binaryPaths[] {
-    "/usr/local/bin/openconnect",
-    "/usr/local/sbin/openconnect",
-    "/usr/bin/openconnect",
-    "/usr/sbin/openconnect",
-    "/opt/bin/openconnect",
-    "/opt/sbin/openconnect"
-};
+static QList<QString> binaryPaths = QList<QString>() <<
+    "/usr/local/bin/openconnect" <<
+     "/usr/local/sbin/openconnect" <<
+     "/usr/bin/openconnect" <<
+     "/usr/sbin/openconnect" <<
+     "/opt/bin/openconnect" <<
+     "/opt/sbin/openconnect";
 
 class GPService : public QObject
 {


### PR DESCRIPTION
Thanks for your hard work @yuezk , you are the one hero who creates the future, not just dreams of it :pray: 

This small PR fixes a segmentation fault in gpservice caused by binary paths array being wrongly iterated up to `binaryPaths->length()`, which is actually a length of the first string in array, not the array length itself. I propose to rewrite array into a list, so that it could be iterated automatically, without explicitly providing an index range. So this way such kind of mistake could be avoided in future. There is an option to measure static array size as `sizeof(array) / sizeof(array[0])`, but I think QList approach is least error-prone.