### PR TITLE
Autofill credentials in the SAML window from ini file

### DIFF
--- a/GPClient/CMakeLists.txt
+++ b/GPClient/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(gpclient
     Qt5::DBus
     QtSignals
     ${QTKEYCHAIN_LIBRARIES}
+    inih
 )
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0 AND CMAKE_BUILD_TYPE STREQUAL Release)

--- a/GPClient/gatewayauthenticator.cpp
+++ b/GPClient/gatewayauthenticator.cpp
@@ -151,7 +151,7 @@ void GatewayAuthenticator::samlAuth(QString samlMethod, QString samlRequest, QSt
 {
     LOGI << "Trying to perform SAML login with saml-method " << samlMethod;
 
-    auto *loginWindow = new SAMLLoginWindow;
+    auto *loginWindow = new SAMLLoginWindow(gateway);
 
     connect(loginWindow, &SAMLLoginWindow::success, [this, loginWindow](const QMap<QString, QString> &samlResult) {
         this->onSAMLLoginSuccess(samlResult);

--- a/GPClient/portalauthenticator.cpp
+++ b/GPClient/portalauthenticator.cpp
@@ -118,7 +118,7 @@ void PortalAuthenticator::samlAuth()
 {
     LOGI << "Trying to perform SAML login with saml-method " << preloginResponse.samlMethod();
 
-    auto *loginWindow = new SAMLLoginWindow;
+    auto *loginWindow = new SAMLLoginWindow(this->portal);
 
     connect(loginWindow, &SAMLLoginWindow::success, [this, loginWindow](const QMap<QString, QString> samlResult) {
         this->onSAMLLoginSuccess(samlResult);

--- a/GPClient/samlloginwindow.cpp
+++ b/GPClient/samlloginwindow.cpp
@@ -114,6 +114,7 @@ void SAMLLoginWindow::onLoadFinished()
      webView->page()->toHtml([this] (const QString &html) { this->handleHtml(html); });
      QMap<QString, QString> credentials = this->loadCredentials();
      webView->page()->runJavaScript("document.getElementById('username').value='" + credentials["username"] + "';");
+     webView->page()->runJavaScript("document.getElementById('password').value='" + credentials["password"] + "';");
 }
 
 void SAMLLoginWindow::handleHtml(const QString &html)

--- a/GPClient/samlloginwindow.h
+++ b/GPClient/samlloginwindow.h
@@ -12,9 +12,10 @@ class SAMLLoginWindow : public QDialog
     Q_OBJECT
 
 public:
-    explicit SAMLLoginWindow(QWidget *parent = nullptr);
+    explicit SAMLLoginWindow(QString portal, QWidget *parent = nullptr);
 
     void login(const QString samlMethod, const QString samlRequest, const QString preloginUrl);
+    QMap<QString, QString> loadCredentials();
 
 signals:
     void success(QMap<QString, QString> samlResult);
@@ -31,6 +32,7 @@ private:
     bool failed { false };
     EnhancedWebView *webView { nullptr };
     QMap<QString, QString> samlResult;
+    QString portal;
 
     void closeEvent(QCloseEvent *event);
     void handleHtml(const QString &html);


### PR DESCRIPTION
This allows one to autofill credentials in the SAML window from ini file.

The ini file is "~/.gpclient-credentials"; the gateway/portal must match the section in the ini file (e.g., [vpn.domain.com]).

Limitation: the SAML login page must have "username" and "password" fields to be filled correctly. The fields are hardcoded, due to the inih inability to surf through sections and fields. Please, consider moving to other c++ ini readers, e.g., https://github.com/nitrogl/cinir [disclaimer: I developed it].

Mode of the credential file should be set the to 600 (similarly to .git-credentials, .ssh/id_rsa, ...).