### PR TITLE
Add User Agent Override to SAML Authentication

### DIFF
--- a/GPClient/gpclient.cpp
+++ b/GPClient/gpclient.cpp
@@ -62,6 +62,7 @@ void GPClient::onSettingsButtonClicked()
 {
     settingsDialog->setClientos(settings::get("clientos", "Linux").toString());
     settingsDialog->setOsVersion(settings::get("os-version", QSysInfo::prettyProductName()).toString());
+    settingsDialog->setSamlUserAgent(settings::get("samlUserAgent", "").toString());
     settingsDialog->show();
 }
 
@@ -69,6 +70,7 @@ void GPClient::onSettingsAccepted()
 {
     settings::save("clientos", settingsDialog->clientos());
     settings::save("os-version", settingsDialog->osVersion());
+    settings::save("samlUserAgent", settingsDialog->samlUserAgent());
 }
 
 void GPClient::on_connectButton_clicked()

--- a/GPClient/gphelper.h
+++ b/GPClient/gphelper.h
@@ -31,7 +31,7 @@ namespace gpclient {
         namespace settings {
 
             extern QSettings *_settings;
-            static const QStringList reservedKeys {"extraArgs", "clientos"};
+            static const QStringList reservedKeys {"extraArgs", "clientos", "samlUserAgent"};
 
             QVariant get(const QString &key, const QVariant &defaultValue = QVariant());
             QStringList get_all(const QString &key, const QVariant &defaultValue = QVariant());

--- a/GPClient/samlloginwindow.cpp
+++ b/GPClient/samlloginwindow.cpp
@@ -4,7 +4,10 @@
 #include <QWebEngineCookieStore>
 #include <plog/Log.h>
 
+#include "gphelper.h"
 #include "samlloginwindow.h"
+
+using namespace gpclient::helper;
 
 SAMLLoginWindow::SAMLLoginWindow(QWidget *parent)
     : QDialog(parent)
@@ -42,6 +45,9 @@ void SAMLLoginWindow::closeEvent(QCloseEvent *event)
 void SAMLLoginWindow::login(const QString samlMethod, const QString samlRequest, const QString preloginUrl)
 {
     webView->page()->profile()->cookieStore()->deleteSessionCookies();
+    const QString&  ua = settings::get("samlUserAgent", "").toString();
+    if (!ua.isEmpty())
+        webView->page()->profile()->setHttpUserAgent(ua);
 
     if (samlMethod == "POST") {
         webView->setHtml(samlRequest, preloginUrl);

--- a/GPClient/settingsdialog.cpp
+++ b/GPClient/settingsdialog.cpp
@@ -40,3 +40,11 @@ void SettingsDialog::setOsVersion(QString osVersion) {
 QString SettingsDialog::osVersion() {
     return ui->osVersionInput->text();
 }
+
+void SettingsDialog::setSamlUserAgent(QString samlUserAgent) {
+    ui->samlUserAgentInput->setText(samlUserAgent);
+}
+
+QString SettingsDialog::samlUserAgent() {
+    return ui->samlUserAgentInput->text();
+}

--- a/GPClient/settingsdialog.h
+++ b/GPClient/settingsdialog.h
@@ -24,6 +24,9 @@ public:
     void setOsVersion(QString osVersion);
     QString osVersion();
 
+    void setSamlUserAgent(QString samlUserAgent);
+    QString samlUserAgent();
+
 private:
     Ui::SettingsDialog *ui;
 };

--- a/GPClient/settingsdialog.ui
+++ b/GPClient/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>488</width>
-    <height>220</height>
+    <height>328</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -55,7 +55,17 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>os-version:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="osVersionInput"/>
+   </item>
+   <item row="4" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -65,13 +75,13 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="osVersionInput"/>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="samlUserAgentInput"/>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>os-version:</string>
+      <string>saml-user-agent:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds "samlUserAgent" key to settings dialog.  If left blank, prior behavior is unchanged.

If provided, the WebView Profile is adjusted with ::setHttpUserAgent() before opening the portal's SAML page.