### PR TITLE
debian: Run dh with --buildsystem=cmake

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export DEBIAN_PACKAGE=1
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake
+
 override_dh_installsystemd:
 	dh_installsystemd gpservice.service


### PR DESCRIPTION

Hi,
the pure repo wont be buildable with 

`dpkg-buildpackage -rfakeroot -b`

because dh is confused about the buildsystem in use. Run dh with --buildsystem=cmake