### PR TITLE
feat: add internal host detection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1436,7 @@ dependencies = [
  "base64 0.21.5",
  "chacha20poly1305",
  "clap",
+ "dns-lookup",
  "log",
  "md5",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.21"
 clap = { version = "4.4.2", features = ["derive"] }
 ctrlc = "3.4"
 directories = "5.0"
+dns-lookup = "2.0.4"
 env_logger = "0.10"
 is_executable = "1.0"
 log = "0.4"

--- a/crates/gpapi/Cargo.toml
+++ b/crates/gpapi/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
+dns-lookup.workspace = true
 log.workspace = true
 reqwest.workspace = true
 openssl.workspace = true

--- a/crates/gpapi/src/gateway/parse_gateways.rs
+++ b/crates/gpapi/src/gateway/parse_gateways.rs
@@ -2,9 +2,17 @@ use roxmltree::Document;
 
 use super::{Gateway, PriorityRule};
 
-pub(crate) fn parse_gateways(doc: &Document) -> Option<Vec<Gateway>> {
+pub(crate) fn parse_gateways(doc: &Document, external: bool) -> Option<Vec<Gateway>> {
   let node_gateways = doc.descendants().find(|n| n.has_tag_name("gateways"))?;
-  let list_gateway = node_gateways.descendants().find(|n| n.has_tag_name("list"))?;
+
+  // if external flag is set, look for external gateways, otherwise look for internal gateways
+  let kind_gateways = if external {
+    node_gateways.descendants().find(|n| n.has_tag_name("external"))?
+  } else {
+    node_gateways.descendants().find(|n| n.has_tag_name("internal"))?
+  };
+
+  let list_gateway = kind_gateways.descendants().find(|n| n.has_tag_name("list"))?;
 
   let gateways = list_gateway
     .children()

--- a/crates/gpapi/tests/files/portal_config.xml
+++ b/crates/gpapi/tests/files/portal_config.xml
@@ -46,7 +46,26 @@
     <use-sso>yes</use-sso>
     <ip-address></ip-address>
     <host></host>
+    <internal-host-detection>
+      <ip-address></ip-address>
+      <host></host>
+      <ipv6-address/>
+      <ipv6-host/>
+    </internal-host-detection>
     <gateways>
+        <internal>
+          <list>
+                <entry name="xxx.xxx.xxx.xxx">
+                    <priority-rule>
+                        <entry name="Any">
+                            <priority>1</priority>
+                        </entry>
+                    </priority-rule>
+                    <priority>1</priority>
+                    <description>vpn_gateway</description>
+                </entry>
+            </list>
+        </internal>
         <cutoff-time>5</cutoff-time>
         <external>
             <list>
@@ -63,6 +82,19 @@
         </external>
     </gateways>
     <gateways-v6>
+        <internal>
+            <list>
+                <entry name="vpn_gateway">
+                    <ipv4>xxx.xxx.xxx.xxx</ipv4>
+                    <priority-rule>
+                        <entry name="Any">
+                            <priority>1</priority>
+                        </entry>
+                    </priority-rule>
+                    <priority>1</priority>
+                </entry>
+            </list>
+        </internal>
         <cutoff-time>5</cutoff-time>
         <external>
             <list>


### PR DESCRIPTION
Adds internal host detection support (reverse DNS lookup). 

Fixes #377

After SAML auth, portal sends in the config a block like the following:

```
<internal-host-detection>
      <ip-address></ip-address>
      <host></host>
      <ipv6-address/>
      <ipv6-host/>
</internal-host-detection>
```
It is meant to be resolved by the client in order to present appropiate gateway list to the user, internal or external gateways, depending on the success of the DNS lookup:

```
<gateways>
        <internal>
          <list>
                <entry name="xxx.xxx.xxx.xxx">
                    <priority-rule>
                        <entry name="Any">
                            <priority>1</priority>
                        </entry>
                    </priority-rule>
                    <priority>1</priority>
                    <description>vpn_gateway</description>
                </entry>
            </list>
        </internal>
        <cutoff-time>5</cutoff-time>
        <external>
            <list>
                <entry name="xxx.xxx.xxx.xxx">
                    <priority-rule>
                        <entry name="Any">
                            <priority>1</priority>
                        </entry>
                    </priority-rule>
                    <priority>1</priority>
                    <description>vpn_gateway</description>
                </entry>
            </list>
        </external>
    </gateways>
```

Sample output when DNS lookup fails (external gateways list is provided):

```
[2024-07-01T21:16:04Z INFO  gpclient::cli] gpclient started: 2.3.3 (2024-07-01)
[2024-07-01T21:16:04Z INFO  gpapi::portal::prelogin] Portal prelogin with user_agent: PAN GlobalProtect
[2024-07-01T21:16:04Z INFO  gpauth::cli] gpauth started: 2.3.3 (2024-07-01)
[2024-07-01T21:16:04Z INFO  gpauth::cli] Please continue the authentication process in the default browser
[2024-07-01T21:16:04Z INFO  gpclient::connect] Waiting for the browser authentication to complete...
[2024-07-01T21:16:04Z INFO  gpclient::connect] Listening authentication data on port 41875
[2024-07-01T21:16:38Z INFO  gpclient::connect] Received the browser authentication data from the socket
[2024-07-01T21:16:38Z INFO  gpapi::auth] Parsing SAML auth data...
[2024-07-01T21:16:38Z INFO  gpapi::portal::config] Portal config, user_agent: PAN GlobalProtect
[2024-07-01T21:16:38Z INFO  gpapi::portal::config] internal-host-detection returned, performing DNS lookup
[2024-07-01T21:16:38Z WARN  gpapi::portal::config] DNS lookup failed for x.x.x.x: failed to lookup address information: Name or service not known
? Which gateway do you want to connect to?
> Germany
  Netherlands
  Hong Kong
  US
  UK
```
I tested the internal use-case by making the DNS resolution successful in local `/etc/hosts` file.

Rust is not a programming language I'm used to, and I'm happy to make any modifications that could improve the code.