### PR TITLE
Fix gpclient disconnect bailing with `client is already running`

### DIFF
--- a/apps/gpclient/src/cli.rs
+++ b/apps/gpclient/src/cli.rs
@@ -111,7 +111,7 @@ impl Cli {
 
   async fn run(&self) -> anyhow::Result<()> {
     // check if an instance is running
-    if self.is_running().await {
+    if !matches!(self.command, CliCommand::Disconnect(_)) && self.is_running().await {
       bail!("Another instance of the client is already running");
     }
 


### PR DESCRIPTION
The command `gpclient disconnect` should disconnect an already running gpclient connection, but instead bails with `client is already running`. The client is expected to be running since the desired behavior is to disconnect an existing connection. Fix the CLI run logic to not bail when the client is already running and a disconnect operation is in progress.

Fixes #533