### PR TITLE
fix: `pkgs.system` use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This repository includes a flake for NixOS integration.
       environment.systemPackages = with pkgs; [
         # ... other packages
       ] ++ [
-        inputs.globalprotect-openconnect.packages.${pkgs.system}.default
+        inputs.globalprotect-openconnect.packages.${pkgs.stdenv.hostPlatform.system}.default
       ];
     }
     ```


### PR DESCRIPTION
Slight adjustment to example for NixOS in README; `pkgs.system` has been renamed to `pkgs.stdenv.hostPlatform.system`