### PR TITLE
fix: `autoreconf: not found` in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
     # Common utilities
+    dh-autoreconf \
     sudo \
     ca-certificates \
     curl \


### PR DESCRIPTION
It fixes the following error while compiling with DevContainer:
```
error: failed to run custom build command for `openconnect v2.5.1 (/workspace/crates/openconnect)`

Caused by:
  process didn't exit successfully: `/workspace/target/release/build/openconnect-f9e2d138f0eeaa92/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=/workspace/crates/openconnect/deps/openconnect
  cargo:rerun-if-changed=/workspace/crates/openconnect/deps/patches/0001-Add-support-for-GlobalProtect-app-version-handling.patch
  Applying patch: /workspace/crates/openconnect/deps/patches/0001-Add-support-for-GlobalProtect-app-version-handling.patch
  patching file gpst.c
  patching file library.c
  patching file openconnect-internal.h
  patching file openconnect.h
  cargo:rerun-if-changed=/workspace/crates/openconnect/deps/patches/0002-Update-user-agent-for-common-headers-in-GlobalProtec.patch
  Applying patch: /workspace/crates/openconnect/deps/patches/0002-Update-user-agent-for-common-headers-in-GlobalProtec.patch
  patching file auth-globalprotect.c
  cargo:rerun-if-changed=/workspace/crates/openconnect/deps/patches/0003-Add-support-for-OS-version-handling-in-GlobalProtect.patch
  Applying patch: /workspace/crates/openconnect/deps/patches/0003-Add-support-for-OS-version-handling-in-GlobalProtect.patch
  patching file auth-globalprotect.c
  patching file gpst.c
  patching file library.c
  patching file openconnect-internal.h
  patching file openconnect.h
  cargo:rerun-if-changed=/workspace/crates/openconnect/deps/patches/0004-Add-client-version-and-OS-information-to-HIP-script-.patch
  Applying patch: /workspace/crates/openconnect/deps/patches/0004-Add-client-version-and-OS-information-to-HIP-script-.patch
  patching file gpst.c
  running: cd "/workspace/target/release/build/openconnect-37dd3e054121faf6/out/openconnect_build" && "sh" "-c" "exec \"$0\" \"$@\"" "autoreconf" "-ivf"

  --- stderr
  autoreconf: 1: exec: autoreconf: not found

  thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/autotools-0.2.7/src/lib.rs:790:5:

  command did not execute successfully, got: exit status: 127

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:105: build-rs] Error 101
```