### PR TITLE
Make `BUILD_GUI=0` avoid using GUI libraries & better errors when spawn fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build-rs:
 	if [ $(BUILD_GUI) -eq 1 ]; then \
 		$(CARGO) build $(CARGO_BUILD_ARGS) -p gpclient -p gpservice -p gpauth -p gpgui-helper; \
 	else \
-		$(CARGO) build $(CARGO_BUILD_ARGS) -p gpclient -p gpservice -p gpauth; \
+		$(CARGO) build $(CARGO_BUILD_ARGS) -p gpclient -p gpservice -p gpauth --no-default-features; \
 	fi
 
 clean:

--- a/README.md
+++ b/README.md
@@ -288,13 +288,16 @@ This project includes a DevContainer configuration that provides a consistent, r
    ```
 
 3. **Build the project:**
+
+   To build everything including the GUI helper run this command:
    ```bash
    docker run --privileged --cap-add=NET_ADMIN --device=/dev/net/tun \
-     -v "$(pwd)":/workspace -w /workspace gpoc-devcontainer \
+     --tty -v "$(pwd)":/workspace -w /workspace gpoc-devcontainer \
      bash -c "export PATH=/usr/local/cargo/bin:\$PATH && make build"
    ```
+   To build without the GUI helper run the same command as above, but with `BUILD_GUI=0` passed as an argument to `make`.
 
-4. **Locate build artifacts:**
+5. **Locate build artifacts:**
 
    The compiled binaries will be available in `target/release/`:
    - `gpclient` – CLI client

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -177,10 +177,16 @@ impl<'a> SamlAuthLauncher<'a> {
     }
 
     let mut non_root_cmd = auth_cmd.into_non_root()?;
-    let output = non_root_cmd
+    let child = non_root_cmd
       .kill_on_drop(true)
       .stdout(Stdio::piped())
-      .spawn()?
+      .spawn();
+
+    if child.is_err() {
+      bail!("Failed to spawn {}: {}", program, child.unwrap_err())
+    }
+
+    let output = child.unwrap()
       .wait_with_output()
       .await?;
 

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -177,18 +177,16 @@ impl<'a> SamlAuthLauncher<'a> {
     }
 
     let mut non_root_cmd = auth_cmd.into_non_root()?;
-    let child = non_root_cmd
-      .kill_on_drop(true)
-      .stdout(Stdio::piped())
-      .spawn();
+    let child = non_root_cmd.kill_on_drop(true).stdout(Stdio::piped()).spawn();
 
-    if child.is_err() {
-      bail!("Failed to spawn {}: {}", program, child.unwrap_err())
-    }
+    let child = match child {
+      Ok(child) => child,
+      Err(err) => {
+        bail!("Failed to spawn {}: {}", program, err);
+      }
+    };
 
-    let output = child.unwrap()
-      .wait_with_output()
-      .await?;
+    let output = child.wait_with_output().await?;
 
     let Ok(auth_result) = serde_json::from_slice::<SamlAuthResult>(&output.stdout) else {
       bail!("Failed to parse auth data")

--- a/crates/gpapi/src/process/gui_helper_launcher.rs
+++ b/crates/gpapi/src/process/gui_helper_launcher.rs
@@ -50,11 +50,12 @@ impl<'a> GuiHelperLauncher<'a> {
 
     info!("Launching gpgui-helper");
     let mut non_root_cmd = cmd.into_non_root()?;
-    let result = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
-    if result.is_err() {
-      bail!("Failed to spawn {}: {}", self.program.display(), result.unwrap_err())
-    }
-    let mut child = result.unwrap();
+    let child = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
+    let mut child = match child {
+      Ok(child) => child,
+      Err(err) => bail!("Failed to spawn {}: {}", self.program.display(), err),
+    };
+
     let Some(mut stdin) = child.stdin.take() else {
       bail!("Failed to open stdin");
     };

--- a/crates/gpapi/src/process/gui_helper_launcher.rs
+++ b/crates/gpapi/src/process/gui_helper_launcher.rs
@@ -50,7 +50,11 @@ impl<'a> GuiHelperLauncher<'a> {
 
     info!("Launching gpgui-helper");
     let mut non_root_cmd = cmd.into_non_root()?;
-    let mut child = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn()?;
+    let result = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
+    if result.is_err() {
+      bail!("Failed to spawn {}: {}", self.program.display(), result.unwrap_err())
+    }
+    let mut child = result.unwrap();
     let Some(mut stdin) = child.stdin.take() else {
       bail!("Failed to open stdin");
     };

--- a/crates/gpapi/src/process/gui_launcher.rs
+++ b/crates/gpapi/src/process/gui_launcher.rs
@@ -69,7 +69,11 @@ impl<'a> GuiLauncher<'a> {
 
     info!("Launching gpgui");
     let mut non_root_cmd = cmd.into_non_root()?;
-    let mut child = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn()?;
+    let result = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
+    if result.is_err() {
+      bail!("Failed to spawn {}: {}", self.program.display(), result.unwrap_err())
+    }
+    let mut child = result.unwrap();
     let Some(mut stdin) = child.stdin.take() else {
       bail!("Failed to open stdin");
     };

--- a/crates/gpapi/src/process/gui_launcher.rs
+++ b/crates/gpapi/src/process/gui_launcher.rs
@@ -69,11 +69,12 @@ impl<'a> GuiLauncher<'a> {
 
     info!("Launching gpgui");
     let mut non_root_cmd = cmd.into_non_root()?;
-    let result = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
-    if result.is_err() {
-      bail!("Failed to spawn {}: {}", self.program.display(), result.unwrap_err())
-    }
-    let mut child = result.unwrap();
+    let child = non_root_cmd.kill_on_drop(true).stdin(Stdio::piped()).spawn();
+    let mut child = match child {
+      Ok(child) => child,
+      Err(err) => bail!("Failed to spawn {}: {}", self.program.display(), err),
+    };
+
     let Some(mut stdin) = child.stdin.take() else {
       bail!("Failed to open stdin");
     };

--- a/crates/gpapi/src/process/hip_launcher.rs
+++ b/crates/gpapi/src/process/hip_launcher.rs
@@ -72,18 +72,14 @@ impl<'a> HipLauncher<'a> {
       cmd.env("APP_VERSION", client_version);
     }
 
-    let child = cmd
-      .kill_on_drop(true)
-      .stdout(Stdio::piped())
-      .spawn();
+    let child = cmd.kill_on_drop(true).stdout(Stdio::piped()).spawn();
 
-    if child.is_err() {
-      bail!("Failed to spawn {}: {}", self.program, child.unwrap_err())
-    }
+    let child = match child {
+      Ok(child) => child,
+      Err(err) => bail!("Failed to spawn {}: {}", self.program, err),
+    };
 
-    let output = child.unwrap()
-      .wait_with_output()
-      .await?;
+    let output = child.wait_with_output().await?;
 
     if let Some(exit_status) = output.status.code() {
       if exit_status != 0 {

--- a/crates/gpapi/src/process/hip_launcher.rs
+++ b/crates/gpapi/src/process/hip_launcher.rs
@@ -72,10 +72,16 @@ impl<'a> HipLauncher<'a> {
       cmd.env("APP_VERSION", client_version);
     }
 
-    let output = cmd
+    let child = cmd
       .kill_on_drop(true)
       .stdout(Stdio::piped())
-      .spawn()?
+      .spawn();
+
+    if child.is_err() {
+      bail!("Failed to spawn {}: {}", self.program, child.unwrap_err())
+    }
+
+    let output = child.unwrap()
       .wait_with_output()
       .await?;
 


### PR DESCRIPTION
I'm in the process of installing this on a headless Debian server, so I tried building with `BUILD_GUI=0` passed to make.  However the resulting binaries didn't run because they linked against quite a few GUI libraries, some of those libraries were missing on my system.  I didn't want to install them as it's a headless server, so I found another solution:

- Commit 8287a669fb43e24434cc6927aa1fdf268dd46a53 changes the `Makefile` to pass `--no-default-features` to `cargo build` in order to disable the `webview-auth` feature, which was what was pulling in the GUI library dependencies.

- Commit 65a93041aa7830e53f95786faa0d18bc410aacac updates the README to mention the `BUILD_GUI=0` argument to make this easier for people to discover.  I also added `--tty` to the docker command line so that the user sees richer output from `cargo` with colours and a progress bar.

Having successfully built binaries that could be run on my machine I then ran `gpclient` with the appropriate arguments, but got the error `Error: No such file or directory (os error 2)`.  I guessed it couldn't find one of the other binaries, but didn't know where it was looking for it, so I improved that error message in order to debug the problem:

- Commit e4426df6a20de4ff73e6f4503fe3a222d7527326 adds explicit handling of tokio::process::Command::spawn() errors and upon failure returns an expanded error message that includes the program path.