### PR TITLE
feat: App support for Intel homebrew builds

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -4,16 +4,28 @@ pub const GP_SERVICE_LOCK_FILE: &str = "/var/run/gpservice.lock";
 pub const GP_CALLBACK_PORT_FILENAME: &str = "gpcallback.port";
 
 // Release binaries - macOS (Apple Silicon Homebrew)
-#[cfg(all(not(debug_assertions), target_os = "macos"))]
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
 pub const GP_CLIENT_BINARY: &str = "/opt/homebrew/bin/gpclient";
-#[cfg(all(not(debug_assertions), target_os = "macos"))]
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
 pub const GP_SERVICE_BINARY: &str = "/opt/homebrew/bin/gpservice";
-#[cfg(all(not(debug_assertions), target_os = "macos"))]
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
 pub const GP_GUI_BINARY: &str = "/opt/homebrew/bin/gpgui";
-#[cfg(all(not(debug_assertions), target_os = "macos"))]
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
 pub const GP_GUI_HELPER_BINARY: &str = "/opt/homebrew/bin/gpgui-helper";
-#[cfg(all(not(debug_assertions), target_os = "macos"))]
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "aarch64"))]
 pub const GP_AUTH_BINARY: &str = "/opt/homebrew/bin/gpauth";
+
+// Release binaries - macOS (Intel Homebrew)
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "x86_64"))]
+pub const GP_CLIENT_BINARY: &str = "/usr/local/bin/gpclient";
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "x86_64"))]
+pub const GP_SERVICE_BINARY: &str = "/usr/local/bin/gpservice";
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "x86_64"))]
+pub const GP_GUI_BINARY: &str = "/usr/local/bin/gpgui";
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "x86_64"))]
+pub const GP_GUI_HELPER_BINARY: &str = "/usr/local/bin/gpgui-helper";
+#[cfg(all(not(debug_assertions), target_os = "macos", target_arch = "x86_64"))]
+pub const GP_AUTH_BINARY: &str = "/usr/local/bin/gpauth";
 
 // Release binaries - Linux
 #[cfg(all(not(debug_assertions), not(target_os = "macos")))]

--- a/crates/openconnect/src/vpn_utils.rs
+++ b/crates/openconnect/src/vpn_utils.rs
@@ -10,9 +10,9 @@ const VPNC_SCRIPT_LOCATIONS: &[&str] = &[
   "/etc/vpnc/vpnc-script",
   "/etc/openconnect/vpnc-script",
   "/usr/libexec/vpnc-scripts/vpnc-script",
-  #[cfg(target_os = "macos", target_arch = "aarch64")]
+  #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
   "/opt/homebrew/etc/vpnc/vpnc-script",
-  #[cfg(target_os = "macos", target_arch = "x86_64")]
+  #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
   "/usr/local/etc/vpnc/vpnc-script",
 ];
 
@@ -24,9 +24,9 @@ const CSD_WRAPPER_LOCATIONS: &[&str] = &[
   "/usr/lib/aarch64-linux-gnu/openconnect/hipreport.sh",
   "/usr/lib/openconnect/hipreport.sh",
   "/usr/libexec/openconnect/hipreport.sh",
-  #[cfg(target_os = "macos", target_arch = "aarch64")]
+  #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
   "/opt/homebrew/opt/openconnect/libexec/openconnect/hipreport.sh",
-  #[cfg(target_os = "macos", target_arch = "x86_64")]
+  #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
   "/usr/local/opt/openconnect/libexec/openconnect/hipreport.sh",
 ];
 

--- a/crates/openconnect/src/vpn_utils.rs
+++ b/crates/openconnect/src/vpn_utils.rs
@@ -10,8 +10,10 @@ const VPNC_SCRIPT_LOCATIONS: &[&str] = &[
   "/etc/vpnc/vpnc-script",
   "/etc/openconnect/vpnc-script",
   "/usr/libexec/vpnc-scripts/vpnc-script",
-  #[cfg(target_os = "macos")]
+  #[cfg(target_os = "macos", target_arch = "aarch64")]
   "/opt/homebrew/etc/vpnc/vpnc-script",
+  #[cfg(target_os = "macos", target_arch = "x86_64")]
+  "/usr/local/etc/vpnc/vpnc-script",
 ];
 
 const CSD_WRAPPER_LOCATIONS: &[&str] = &[
@@ -22,8 +24,10 @@ const CSD_WRAPPER_LOCATIONS: &[&str] = &[
   "/usr/lib/aarch64-linux-gnu/openconnect/hipreport.sh",
   "/usr/lib/openconnect/hipreport.sh",
   "/usr/libexec/openconnect/hipreport.sh",
-  #[cfg(target_os = "macos")]
+  #[cfg(target_os = "macos", target_arch = "aarch64")]
   "/opt/homebrew/opt/openconnect/libexec/openconnect/hipreport.sh",
+  #[cfg(target_os = "macos", target_arch = "x86_64")]
+  "/usr/local/opt/openconnect/libexec/openconnect/hipreport.sh",
 ];
 
 fn find_executable(locations: &[&'static str]) -> Option<&'static str> {

--- a/packaging/files/usr/libexec/gpclient/hipreport.sh
+++ b/packaging/files/usr/libexec/gpclient/hipreport.sh
@@ -4,13 +4,16 @@
 LOGFILE="/tmp/gpclient-hipreport.log"
 
 LINUX_GPCLIENT_BIN="/usr/bin/gpclient"
-HOMEBREW_GPCLIENT_BIN="/opt/homebrew/bin/gpclient"
+ARM64_HOMEBREW_GPCLIENT_BIN="/opt/homebrew/bin/gpclient"
+X86_64_HOMEBREW_GPCLIENT_BIN="/usr/local/bin/gpclient"
 GPCLIENT_BIN=""
 
 if [ -x "$LINUX_GPCLIENT_BIN" ]; then
     GPCLIENT_BIN="$LINUX_GPCLIENT_BIN"
-elif [ -x "$HOMEBREW_GPCLIENT_BIN" ]; then
-    GPCLIENT_BIN="$HOMEBREW_GPCLIENT_BIN"
+elif [ -x "$ARM64_HOMEBREW_GPCLIENT_BIN" ]; then
+    GPCLIENT_BIN="$ARM64_HOMEBREW_GPCLIENT_BIN"
+elif [ -x "$X86_64_HOMEBREW_GPCLIENT_BIN" ]; then
+    GPCLIENT_BIN="$X86_64_HOMEBREW_GPCLIENT_BIN"
 else
     echo "Error: gpclient binary not found." > "$LOGFILE"
     exit 1


### PR DESCRIPTION
In https://github.com/yuezk/GlobalProtect-openconnect/pull/557 all path are hard-coded as apple silicon homebrew prefix. I added Intel homebrew prefix in this PR.