### PR TITLE
Add codespell support: config, CI workflow, and false-positive guards

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,7 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,*-lock.yaml,*.lock,*.css,.codespellrc
+skip = .git*,*.svg,*-lock.yaml,*.lock,*.css,.codespellrc,*/dist/*,*.min.js
 check-hidden = true
-# ignore-regex = 
+# Ignore URLs (typos in URLs must not be "fixed" — would break links)
+ignore-regex = https?://\S+
 # ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,*-lock.yaml,*.lock,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Annotate locations with typos
-        uses: codespell-project/codespell-problem-matcher@v1
+        uses: actions/checkout@v6
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/crates/gpapi/src/utils/redact.rs
+++ b/crates/gpapi/src/utils/redact.rs
@@ -142,9 +142,9 @@ mod tests {
 
   #[test]
   fn it_should_not_redact_value() {
-    let text = "fo";
+    let text = "fo"; // codespell:ignore fo
 
-    assert_eq!(redact_value(text), "fo");
+    assert_eq!(redact_value(text), "fo"); // codespell:ignore fo
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Add [codespell](https://github.com/codespell-project/codespell) to catch typos in
sources and docs, and wire it into CI so future typos are caught at PR time.

This project has previously merged manual typo cleanups (e.g.
7bef2cc `Fix typos found by codespell (#234)`) — automating the check
removes the burden of remembering to run it.

I've introduced codespell into 100+ projects with mostly positive feedback
(see [this writeup](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).
The CI workflow has `permissions: contents: read` only, so it's safe.

## Commits

- 702e88d `Add github action to codespell main on push and PRs`
- 47ef75f `Add rudimentary codespell config`
- 06bada9 `Refine codespell config: skip dist/ and minified JS, ignore URLs`
- d622391 `ci(codespell): bump checkout to v6, pin codespell action by SHA`
- b79bb6d `test(redact): mark intentional short test fixture for codespell`

<details><summary>Per-commit details</summary>

### 702e88d `Add github action to codespell main on push and PRs`

`.github/workflows/codespell.yml` runs on `push` / `pull_request` against
`main`, with `contents: read` only.

### 47ef75f `Add rudimentary codespell config`

Initial `.codespellrc` with a conservative skip list and `check-hidden = true`.

### 06bada9 `Refine codespell config: skip dist/ and minified JS, ignore URLs`

- Skip `*/dist/*` and `*.min.js` — `apps/gpgui-helper/dist/assets/main-*.js`
  is a tracked, built/minified bundle that triggers ~120 false positives
  (`te`, `fo`, `nd`, …). The source lives in `apps/gpgui-helper/src/` and
  is still checked.
- Add `ignore-regex = https?://\S+` so codespell never "corrects" typos
  inside URLs (would silently break links).

### d622391 `ci(codespell): bump checkout to v6, pin codespell action by SHA`

- Bump `actions/checkout` to v6.
- Pin `codespell-project/actions-codespell` to a SHA at v2.2 (supply-chain hygiene).
- Drop the separate `codespell-problem-matcher` step — annotation support is
  built into `actions-codespell@v2.2+`, so the extra step is now redundant.

### b79bb6d `test(redact): mark intentional short test fixture for codespell`

`crates/gpapi/src/utils/redact.rs::it_should_not_redact_value` uses the
literal `"fo"` to verify that values shorter than the redaction threshold
pass through unchanged. codespell flags `fo`, so I added two inline
`// codespell:ignore fo` pragmas on the affected lines. This keeps the
project-wide `ignore-words-list` empty — future genuine typos of `fo`
elsewhere will still be caught.

</details>

## Testing

- [x] `uvx codespell` passes with zero errors on this branch
- [x] No production code logic changed; only test-file comments and config
- [x] Built/minified `dist/` bundles excluded from scanning (false-positive heavy)
- [x] URLs protected from auto-"correction" via `ignore-regex`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typo-free code
