### PR TITLE
feat: add Microsoft Defender anti-malware HIP reporting support for linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "netdev",
  "openconnect",
  "reqwest 0.12.28",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "sysinfo",

--- a/apps/gpclient/Cargo.toml
+++ b/apps/gpclient/Cargo.toml
@@ -20,6 +20,7 @@ inquire = "0.9"
 log.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 sysinfo.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 whoami.workspace = true

--- a/apps/gpclient/src/hip.rs
+++ b/apps/gpclient/src/hip.rs
@@ -2,7 +2,9 @@ use askama::Template;
 use clap::Args;
 use gpapi::{clap::args::Os, utils::host_utils};
 use log::debug;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::process::Command;
 use xmltree::Element;
 
 #[derive(Template)]
@@ -16,6 +18,25 @@ struct HipReportTemplate<'a> {
   user_name: &'a str,
   host_info: HostInfo<'a>,
   md5: &'a str,
+}
+
+/// Information about Microsoft Defender (mdatp) installation and status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DefenderInfo {
+  #[serde(rename = "appVersion")]
+  app_version: String,
+  #[serde(rename = "engineVersion")]
+  engine_version: String,
+  #[serde(rename = "definitionsVersion")]
+  definitions_version: String,
+  #[serde(rename = "realTimeProtectionEnabled")]
+  real_time_protection_enabled: RealTimeProtection,
+}
+
+/// Wrapper for realTimeProtectionEnabled field which has a nested structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RealTimeProtection {
+  value: bool,
 }
 
 /// Host information for HIP reporting
@@ -32,6 +53,8 @@ struct HostInfo<'a> {
   software_version: &'a str,
   domain: String,
   network_interfaces: Vec<NetworkInterface>,
+  /// Linux only: Microsoft Defender (mdatp) information if available
+  defender: Option<DefenderInfo>,
 }
 
 impl<'a> HostInfo<'a> {
@@ -238,6 +261,9 @@ impl<'a> HostInfoCollector<'a> {
       ipv6: iface.ipv6,
     };
 
+    // Try to detect Microsoft Defender on Linux
+    let defender = detect_microsoft_defender_blocking();
+
     HostInfo {
       os_vendor: "Linux",
       os_version: &self.args.os_version,
@@ -246,6 +272,7 @@ impl<'a> HostInfoCollector<'a> {
       software_version: "",
       domain: String::new(),
       network_interfaces: vec![iface],
+      defender,
     }
   }
 
@@ -284,6 +311,7 @@ impl<'a> HostInfoCollector<'a> {
       software_version: host_utils::get_macos_version(),
       domain: self.get_domain(),
       network_interfaces: vec![iface],
+      defender: None,
     }
   }
 
@@ -334,8 +362,38 @@ impl<'a> HostInfoCollector<'a> {
       software_version: host_utils::get_windows_version(),
       domain: self.get_domain(),
       network_interfaces: ifaces,
+      defender: None,
     }
   }
+}
+
+// ============================================================================
+// Microsoft Defender Detection
+// ============================================================================
+
+/// Detect Microsoft Defender (mdatp) on Linux systems
+/// Executes 'mdatp health --output json' and parses the result
+fn detect_microsoft_defender_blocking() -> Option<DefenderInfo> {
+  // Try to execute 'mdatp health --output json'
+  let output = Command::new("mdatp")
+    .arg("health")
+    .arg("--output")
+    .arg("json")
+    .output()
+    .ok()?;
+
+  // Check if command executed successfully
+  if !output.status.success() {
+    debug!("mdatp health command failed");
+    return None;
+  }
+
+  // Parse JSON output
+  let json_str = String::from_utf8(output.stdout).ok()?;
+  let defender_info: DefenderInfo = serde_json::from_str(&json_str).ok()?;
+
+  debug!("Detected Microsoft Defender: {:?}", defender_info);
+  Some(defender_info)
 }
 
 // ============================================================================

--- a/apps/gpclient/templates/hip_report.xml
+++ b/apps/gpclient/templates/hip_report.xml
@@ -218,7 +218,20 @@
 		</entry>
     {% elif host_info.os_vendor == "Linux" -%}
 		<entry name="anti-malware">
+			{% if let Some(defender) = &host_info.defender -%}
+			<list>
+				<entry>
+					<ProductInfo>
+						<Prod name="Microsoft Defender ATP" version="{{ defender.app_version }}" defver="{{ defender.definitions_version }}" prodType="3" engver="{{ defender.engine_version }}" osType="1" vendor="Microsoft Corporation" dateday="{{ day }}" dateyear="{{ year }}" datemon="{{ month }}">
+						</Prod>
+						<real-time-protection>{% if defender.real_time_protection_enabled.value %}yes{% else %}no{% endif %}</real-time-protection>
+						<last-full-scan-time>n/a</last-full-scan-time>
+					</ProductInfo>
+				</entry>
+			</list>
+			{% else -%}
 			<list/>
+			{% endif -%}
 		</entry>
 		<entry name="disk-backup">
 			<list/>


### PR DESCRIPTION
DISCLAIMER: This is 100% vibe coded and may be complete slop, I don't know a lick of rust. If that's the case I sincerely apologize, I don't want to make things harder for you.

My org requires Defender running and for it to be included in the HIP report to connect to VPN, so I took a shot at getting it to work. After building it with some AI tools and trying it, everything built and it seems to work great! If I stop mdatp service, the report reverted to the default blank entry.

During report generation, it pulls the values from mdatp and includes them in the report if the command runs successfully. If not it defaults to an empty list just as before.

I have only tested this on linux (Kubuntu 26.04) and only the CLI (my GUI trial ran out). I don't know if this negatively affects other OSs or other configurations, but it looks safe based on my limited reading of the changes.