### PR TITLE
feat: add prebuilt Nix package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,6 +306,51 @@ jobs:
           gpgui-source/*.bin.tar.xz
           gpgui-source/*.bin.tar.xz.sha256
 
+  build-nix-prebuilt:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            nixpkgs: nixos-25.11
+          - runner: ubuntu-latest
+            nixpkgs: nixos-26.05
+          - runner: ubuntu-24.04-arm
+            nixpkgs: nixos-25.11
+          - runner: ubuntu-24.04-arm
+            nixpkgs: nixos-26.05
+    name: build-nix-prebuilt (${{ matrix.nixpkgs }}, ${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - name: Checkout GlobalProtect-openconnect
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GH_PAT }}
+        repository: yuezk/GlobalProtect-openconnect
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.gp_branch || github.ref }}
+        submodules: recursive
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+
+    - name: Build prebuilt Nix package
+      run: |
+        nix build .#prebuilt \
+          --override-input nixpkgs "github:NixOS/nixpkgs/${{ matrix.nixpkgs }}" \
+          --extra-experimental-features "nix-command flakes" \
+          --print-build-logs
+
+    - name: Smoke test prebuilt Nix package
+      run: |
+        result/bin/gpclient --version
+        result/bin/gpauth --version
+        result/bin/gpservice --version
+        result/bin/gpgui-helper --version
+        result/bin/gpgui --version
+
+        ! grep -R '/usr/bin/gp' result/share result/libexec
+
   setup-bsd-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/apps/gpservice/src/handlers.rs
+++ b/apps/gpservice/src/handlers.rs
@@ -3,7 +3,6 @@ use std::{
   io::BufReader,
   ops::ControlFlow,
   os::unix::fs::PermissionsExt,
-  path::PathBuf,
   sync::Arc,
 };
 
@@ -17,7 +16,7 @@ use axum::{
   http::StatusCode,
   response::IntoResponse,
 };
-use common::constants::GP_GUI_BINARY;
+use common::binary_paths;
 use futures::{SinkExt, StreamExt};
 use gpapi::{
   service::{event::WsEvent, request::UpdateGuiRequest},
@@ -67,8 +66,8 @@ pub async fn update_gui(State(ctx): State<Arc<WsServerContext>>, body: Bytes) ->
 
 // Unpack GPGUI archive, gpgui_2.0.0_{arch}.bin.tar.xz and install it
 async fn install_gui(src: &str) -> anyhow::Result<()> {
-  let path = PathBuf::from(GP_GUI_BINARY);
-  let Some(dir) = path.parent() else {
+  let target = binary_paths::gpgui();
+  let Some(dir) = target.parent() else {
     bail!("Failed to get parent directory of GUI binary");
   };
 
@@ -81,13 +80,13 @@ async fn install_gui(src: &str) -> anyhow::Result<()> {
 
   for entry in ar.entries()? {
     let mut entry = entry?;
-    let path = entry.path()?;
+    let entry_path = entry.path()?;
 
-    if let Some(name) = path.file_name() {
+    if let Some(name) = entry_path.file_name() {
       let name = name.to_string_lossy();
 
       if name == "gpgui" {
-        let mut file = File::create(GP_GUI_BINARY)?;
+        let mut file = File::create(&target)?;
         std::io::copy(&mut entry, &mut file)?;
         break;
       }
@@ -95,7 +94,7 @@ async fn install_gui(src: &str) -> anyhow::Result<()> {
   }
 
   // Make the binary executable
-  fs::set_permissions(GP_GUI_BINARY, Permissions::from_mode(0o755)).await?;
+  fs::set_permissions(target, Permissions::from_mode(0o755)).await?;
 
   Ok(())
 }

--- a/apps/gpservice/src/ws_server.rs
+++ b/apps/gpservice/src/ws_server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use axum::extract::ws::Message;
-use common::constants::GP_AUTH_BINARY;
+use common::binary_paths;
 use gpapi::{
   os_profile::HostIdentity,
   service::{
@@ -73,7 +73,7 @@ impl WsServerContext {
       vpn_state: self.vpn_state_rx.borrow().clone(),
       vpnc_script: find_vpnc_script().map(|s| s.to_owned()),
       csd_wrapper: find_csd_wrapper().map(|s| s.to_owned()),
-      auth_executable: GP_AUTH_BINARY.to_owned(),
+      auth_executable: binary_paths::gpauth().to_string_lossy().into_owned(),
       host_info,
     };
 

--- a/crates/common/src/binary_paths.rs
+++ b/crates/common/src/binary_paths.rs
@@ -1,0 +1,58 @@
+use std::{
+  env,
+  path::{Path, PathBuf},
+};
+
+use crate::constants::{GP_AUTH_BINARY, GP_CLIENT_BINARY, GP_GUI_BINARY, GP_GUI_HELPER_BINARY, GP_SERVICE_BINARY};
+
+pub fn gpclient() -> PathBuf {
+  resolve("GP_CLIENT_BINARY", "gpclient", GP_CLIENT_BINARY)
+}
+
+pub fn gpservice() -> PathBuf {
+  resolve("GP_SERVICE_BINARY", "gpservice", GP_SERVICE_BINARY)
+}
+
+pub fn gpauth() -> PathBuf {
+  resolve("GP_AUTH_BINARY", "gpauth", GP_AUTH_BINARY)
+}
+
+pub fn gpgui() -> PathBuf {
+  resolve("GP_GUI_BINARY", "gpgui", GP_GUI_BINARY)
+}
+
+pub fn gpgui_helper() -> PathBuf {
+  resolve("GP_GUI_HELPER_BINARY", "gpgui-helper", GP_GUI_HELPER_BINARY)
+}
+
+fn resolve(env_key: &str, binary_name: &str, default_path: &str) -> PathBuf {
+  env::var_os(env_key)
+    .filter(|value| !value.is_empty())
+    .map(PathBuf::from)
+    .or_else(|| sibling_binary(binary_name))
+    .unwrap_or_else(|| PathBuf::from(default_path))
+}
+
+fn sibling_binary(binary_name: &str) -> Option<PathBuf> {
+  let current_exe = env::current_exe().ok()?;
+  let bin_dir = current_exe.parent()?;
+  let binary = bin_dir.join(binary_name);
+
+  is_file(&binary).then_some(binary)
+}
+
+fn is_file(path: &Path) -> bool {
+  path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn default_path_is_used_when_no_sibling_exists() {
+    let path = resolve("GP_TEST_BINARY", "missing-gp-test-binary", "/usr/bin/gp-test");
+
+    assert_eq!(path, PathBuf::from("/usr/bin/gp-test"));
+  }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod binary_paths;
 pub mod constants;

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -1,7 +1,7 @@
-use std::process::Stdio;
+use std::{path::PathBuf, process::Stdio};
 
 use anyhow::bail;
-use common::constants::GP_AUTH_BINARY;
+use common::binary_paths;
 use tokio::process::Command;
 
 use crate::{auth::SamlAuthResult, credential::Credential, os_profile::OsProfile};
@@ -113,8 +113,11 @@ impl<'a> SamlAuthLauncher<'a> {
 
   /// Launch the authenticator binary as the current user or SUDO_USER if available.
   pub async fn launch(self) -> anyhow::Result<Credential> {
-    let program = self.auth_executable.unwrap_or(GP_AUTH_BINARY);
-    let mut auth_cmd = Command::new(program);
+    let program = self
+      .auth_executable
+      .map(PathBuf::from)
+      .unwrap_or_else(binary_paths::gpauth);
+    let mut auth_cmd = Command::new(&program);
     auth_cmd.arg(self.server);
 
     if self.gateway {
@@ -174,7 +177,7 @@ impl<'a> SamlAuthLauncher<'a> {
     let child = match child {
       Ok(child) => child,
       Err(err) => {
-        bail!("Failed to spawn {}: {}", program, err);
+        bail!("Failed to spawn {}: {}", program.display(), err);
       }
     };
 

--- a/crates/gpapi/src/process/gui_helper_launcher.rs
+++ b/crates/gpapi/src/process/gui_helper_launcher.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::PathBuf, process::Stdio};
 
 use anyhow::bail;
-use common::constants::GP_GUI_HELPER_BINARY;
+use common::binary_paths;
 use log::info;
 use tokio::{io::AsyncWriteExt, process::Command};
 
@@ -17,7 +17,7 @@ pub struct GuiHelperLauncher<'a> {
 impl<'a> GuiHelperLauncher<'a> {
   pub fn new(api_key: &'a [u8]) -> Self {
     Self {
-      program: GP_GUI_HELPER_BINARY.into(),
+      program: binary_paths::gpgui_helper(),
       envs: None,
       api_key,
       gui_version: None,

--- a/crates/gpapi/src/process/gui_launcher.rs
+++ b/crates/gpapi/src/process/gui_launcher.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::bail;
-use common::constants::GP_GUI_BINARY;
+use common::binary_paths;
 use log::info;
 use tokio::{io::AsyncWriteExt, process::Command};
 
@@ -25,7 +25,7 @@ impl<'a> GuiLauncher<'a> {
   pub fn new(version: &'a str, api_key: &'a [u8]) -> Self {
     Self {
       version,
-      program: GP_GUI_BINARY.into(),
+      program: binary_paths::gpgui(),
       api_key,
       minimized: false,
       envs: None,

--- a/crates/gpapi/src/process/service_launcher.rs
+++ b/crates/gpapi/src/process/service_launcher.rs
@@ -4,7 +4,7 @@ use std::{
   process::{ExitStatus, Stdio},
 };
 
-use common::constants::GP_SERVICE_BINARY;
+use common::binary_paths;
 use tokio::process::Command;
 
 use super::command_traits::CommandExt;
@@ -26,7 +26,7 @@ impl Default for ServiceLauncher<'_> {
 impl<'a> ServiceLauncher<'a> {
   pub fn new() -> Self {
     Self {
-      program: GP_SERVICE_BINARY.into(),
+      program: binary_paths::gpservice(),
       minimized: false,
       env_file: None,
       log_file: None,

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           inherit system;
           overlays = [ (import rust-overlay) ];
         };
+        inherit (pkgs) lib;
 
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         pname = "globalprotect-openconnect";
@@ -40,41 +41,76 @@
 
         cpu = pkgs.stdenv.hostPlatform.parsed.cpu.name;
 
+        gpguiHashes = {
+          x86_64 = "sha256-jLMErGlfbzhRk8onqqiRXOMeNhdFWBZGOqPPEh9vLyM=";
+          aarch64 = "sha256-YSjn2oxDaKTtdfK7rsmuMZfD9n1bitVbScIW0fyedXI=";
+        };
+
         gpgui = pkgs.fetchzip {
           url = "https://github.com/yuezk/GlobalProtect-openconnect/releases/download/v${version}/gpgui_${cpu}.bin.tar.xz";
-          hash = {
-            x86_64 = "sha256-jLMErGlfbzhRk8onqqiRXOMeNhdFWBZGOqPPEh9vLyM=";
-            aarch64 = "sha256-YSjn2oxDaKTtdfK7rsmuMZfD9n1bitVbScIW0fyedXI=";
-          }.${cpu};
+          hash = gpguiHashes.${cpu};
         };
-      in
-      {
-        # For `nix build`
-        packages.default = naersk'.buildPackage {
+
+        binaryHashes = {
+          x86_64 = "sha256-atZRM7v5areQTDkrJrOczSz0tc3P6aGU+BE4VblNE08=";
+          aarch64 = "sha256-ENE0fHlLSt493QIlotaIMf11MszJszl4ZZAsYWuFJeE=";
+        };
+
+        binaryPackage = pkgs.fetchzip {
+          url = "https://github.com/yuezk/GlobalProtect-openconnect/releases/download/v${version}/globalprotect-openconnect_${version}_${cpu}.bin.tar.xz";
+          hash = binaryHashes.${cpu};
+        };
+
+        linuxRuntimeDependencies = with pkgs; [
+          glib-networking
+          libappindicator-gtk3
+        ];
+
+        linuxBuildInputs =
+          with pkgs;
+          [
+            libxml2
+            zlib
+            lz4
+            gnutls
+            p11-kit
+            nettle
+            gmp
+          ]
+          ++ lib.optionals stdenv.isLinux [
+            glib
+            gtk3
+            libsoup_3
+            webkitgtk_4_1
+            glib-networking
+            openssl
+            libsecret
+            libappindicator-gtk3
+          ];
+
+        rewriteInstallPaths = ''
+          substituteInPlace $out/share/applications/gpgui.desktop \
+            --replace-fail /usr/bin/gpclient $out/bin/gpclient
+
+          substituteInPlace $out/libexec/gpclient/hipreport.sh \
+            --replace-fail /usr/bin/gpclient $out/bin/gpclient
+
+          substituteInPlace $out/share/polkit-1/actions/com.yuezk.gpgui.policy \
+            --replace-fail /usr/bin/gpservice $out/bin/gpservice
+
+          if [ -f $out/lib/NetworkManager/dispatcher.d/pre-down.d/gpclient.down ]; then
+            substituteInPlace $out/lib/NetworkManager/dispatcher.d/pre-down.d/gpclient.down \
+              --replace-fail /usr/bin/gpclient $out/bin/gpclient
+          fi
+        '';
+
+        fromSource = naersk'.buildPackage {
           inherit pname version src;
 
           # Must be set to true to avoid issues with the Tauri build process
           singleStep = true;
 
-          buildInputs =
-            with pkgs;
-            [
-              libxml2
-              zlib
-              lz4
-              gnutls
-              p11-kit
-              nettle
-              gmp
-            ]
-            ++ lib.optionals stdenv.isLinux [
-              glib
-              gtk3
-              libsoup_3
-              webkitgtk_4_1
-              glib-networking
-              openssl
-            ];
+          buildInputs = linuxBuildInputs;
 
           nativeBuildInputs =
             with pkgs;
@@ -89,13 +125,7 @@
               wrapGAppsHook4
             ];
 
-          runtimeDependencies =
-            with pkgs;
-            [ ]
-            ++ lib.optionals stdenv.isLinux [
-              libappindicator-gtk3
-              glib-networking
-            ];
+          runtimeDependencies = lib.optionals pkgs.stdenv.isLinux linuxRuntimeDependencies;
 
           overrideMain =
             { ... }:
@@ -124,22 +154,55 @@
             cp -r packaging/files/usr/lib $out/lib
             cp -r packaging/files/usr/libexec $out/libexec
 
-            # Change the `/usr/bin/gpclient` path in the desktop file
-            substituteInPlace $out/share/applications/gpgui.desktop \
-              --replace-fail /usr/bin/gpclient $out/bin/gpclient
-
-            substituteInPlace $out/lib/NetworkManager/dispatcher.d/pre-down.d/gpclient.down \
-              --replace-fail /usr/bin/gpclient $out/bin/gpclient
-
-            substituteInPlace $out/libexec/gpclient/hipreport.sh \
-              --replace-fail /usr/bin/gpclient $out/bin/gpclient
-
-            # Change the `/usr/bin/gpservice` path in the polkit policy file
-            substituteInPlace $out/share/polkit-1/actions/com.yuezk.gpgui.policy \
-              --replace-fail /usr/bin/gpservice $out/bin/gpservice
-
+            ${rewriteInstallPaths}
           '';
         };
+
+        prebuilt = pkgs.stdenv.mkDerivation {
+          inherit pname version;
+
+          src = binaryPackage;
+          dontBuild = true;
+
+          nativeBuildInputs = with pkgs; [
+            autoPatchelfHook
+            wrapGAppsHook4
+          ];
+
+          buildInputs = linuxBuildInputs;
+          runtimeDependencies = linuxRuntimeDependencies;
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out
+            cp -r artifacts/usr/bin $out/bin
+            cp -r artifacts/usr/libexec $out/libexec
+            cp -r artifacts/usr/share $out/share
+
+            if [ -d artifacts/usr/lib ]; then
+              cp -r artifacts/usr/lib $out/lib
+            fi
+
+            ${rewriteInstallPaths}
+
+            runHook postInstall
+          '';
+        };
+      in
+      {
+        # For `nix build`
+        packages =
+          {
+            fromSource = fromSource;
+          }
+          // lib.optionalAttrs pkgs.stdenv.isLinux {
+            default = prebuilt;
+            prebuilt = prebuilt;
+          }
+          // lib.optionalAttrs (!pkgs.stdenv.isLinux) {
+            default = fromSource;
+          };
 
         apps.default = {
           type = "app";

--- a/scripts/update-flake-hashes.sh
+++ b/scripts/update-flake-hashes.sh
@@ -73,18 +73,26 @@ release_url() {
 source_hash="$(prefetch_hash "$(release_url "globalprotect-openconnect-$version.tar.gz")")"
 gpgui_x86_64_hash="$(prefetch_hash "$(release_url "gpgui_x86_64.bin.tar.xz")")"
 gpgui_aarch64_hash="$(prefetch_hash "$(release_url "gpgui_aarch64.bin.tar.xz")")"
+binary_x86_64_hash="$(prefetch_hash "$(release_url "globalprotect-openconnect_${version}_x86_64.bin.tar.xz")")"
+binary_aarch64_hash="$(prefetch_hash "$(release_url "globalprotect-openconnect_${version}_aarch64.bin.tar.xz")")"
 
 SOURCE_HASH="$source_hash" \
 GPGUI_X86_64_HASH="$gpgui_x86_64_hash" \
 GPGUI_AARCH64_HASH="$gpgui_aarch64_hash" \
+BINARY_X86_64_HASH="$binary_x86_64_hash" \
+BINARY_AARCH64_HASH="$binary_aarch64_hash" \
 perl -0pi -e '
   s|(url = "https://github\.com/yuezk/GlobalProtect-openconnect/releases/download/v\$\{version\}/globalprotect-openconnect-\$\{version\}\.tar\.gz";\n\s*hash = ")[^"]+(";)|$1 . $ENV{"SOURCE_HASH"} . $2|e;
-  s|(x86_64 = ")[^"]+(";)|$1 . $ENV{"GPGUI_X86_64_HASH"} . $2|e;
-  s|(aarch64 = ")[^"]+(";)|$1 . $ENV{"GPGUI_AARCH64_HASH"} . $2|e;
+  s|(gpguiHashes = \{\n\s*x86_64 = ")[^"]+(";)|$1 . $ENV{"GPGUI_X86_64_HASH"} . $2|e;
+  s|(gpguiHashes = \{\n\s*x86_64 = "[^"]+";\n\s*aarch64 = ")[^"]+(";)|$1 . $ENV{"GPGUI_AARCH64_HASH"} . $2|e;
+  s|(binaryHashes = \{\n\s*x86_64 = ")[^"]+(";)|$1 . $ENV{"BINARY_X86_64_HASH"} . $2|e;
+  s|(binaryHashes = \{\n\s*x86_64 = "[^"]+";\n\s*aarch64 = ")[^"]+(";)|$1 . $ENV{"BINARY_AARCH64_HASH"} . $2|e;
 ' "$FLAKE_FILE"
 
 grep -F "$source_hash" "$FLAKE_FILE" > /dev/null
 grep -F "$gpgui_x86_64_hash" "$FLAKE_FILE" > /dev/null
 grep -F "$gpgui_aarch64_hash" "$FLAKE_FILE" > /dev/null
+grep -F "$binary_x86_64_hash" "$FLAKE_FILE" > /dev/null
+grep -F "$binary_aarch64_hash" "$FLAKE_FILE" > /dev/null
 
 echo "Updated flake.nix hashes for v$version"


### PR DESCRIPTION
## Summary

- Add a Nix prebuilt package path that installs the published 2.6.0 binary release instead of rebuilding from source.
- Keep the source-based Nix package available for users who still need it.
- Add CI smoke coverage for the prebuilt Nix package on NixOS 25.11 and 26.05 for x86_64 and aarch64.

## Main Changes

- Add runtime binary path resolution so binaries installed together in the Nix store can locate gpclient, gpservice, gpauth, gpgui, and gpgui-helper reliably.
- Add a Linux prebuilt derivation in flake.nix that fetches the 2.6.0 release tarballs, patches installed metadata, wraps GUI binaries, and exposes it as the default Linux package.
- Extend the flake hash update script to refresh binary release hashes.
- Add a build-nix-prebuilt workflow job that builds and smoke-tests the prebuilt package across supported NixOS channels and CPU architectures.

## API / Usage

nix build .#prebuilt
nix build .#fromSource

## Verification

- cargo fmt -p common -p gpapi -p gpservice
- cargo test -p common binary_paths
- cargo check -p gpapi
- cargo check -p gpservice
- bash -n scripts/update-flake-hashes.sh
- git diff --check
- GitHub Actions Build run 27875190970 passed
