### PR TITLE
Remove GUI dependencies from apk when GUI components are disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,17 @@ init-apk: clean-apk tarball
 	checksum=$$(sha512sum .build/apk/${PKG}.tar.gz | cut -d' ' -f1); \
 		sed -i "s/@SHA512@/$$checksum/g" .build/apk/APKBUILD
 
+	# Remove the GUI dependencies if BUILD_GUI_HELPER is set to 0
+	if [ $(BUILD_GUI_HELPER) -eq 0 ]; then \
+		sed -i "/^\tlibayatana-appindicator$$/d" .build/apk/APKBUILD; \
+		sed -i "/^\tlibsecret$$/d" .build/apk/APKBUILD; \
+	fi
+
+	# Remove the WebKitGTK dependency only if neither gpauth webview auth nor gpgui-helper needs it
+	if [ $(BUILD_GUI_HELPER) -eq 0 ] && [ $(BUILD_WEBVIEW_AUTH) -eq 0 ]; then \
+		sed -i "/^\twebkit2gtk-4.1$$/d" .build/apk/APKBUILD; \
+	fi
+
 apk: init-apk
 	cd .build/apk && abuild -r -P "$(CURDIR)/.build/apk/packages"
 


### PR DESCRIPTION
`packaging/apk/APKBUILD.in` already passes `INCLUDE_GUI`, `BUILD_GUI_HELPER` and
`BUILD_WEBVIEW_AUTH` through to the build, so a headless apk **builds** fine. But
`depends=` is a fixed list that always includes the GUI stack, so `apk add` still
installs the whole webview closure — on Alpine that closure is larger than the
rest of the system.

`init-debian` already solves this. This mirrors it in `init-apk`, with the same
two conditions:

- `BUILD_GUI_HELPER=0` → drop `libayatana-appindicator`, `libsecret`
- `BUILD_GUI_HELPER=0` **and** `BUILD_WEBVIEW_AUTH=0` → drop `webkit2gtk-4.1`
  (either component needs it)

Defaults are untouched, so released packages are unaffected.

### Effect

Two fresh `alpine:3.23` aarch64 containers, both `2.6.4-r1`, identical base of
`nftables iproute2 ca-certificates curl` (23 MiB / 41 packages):

| | install adds | packages |
| --- | --- | --- |
| stock release `.apk` | 582 MiB | 214 |
| this patch, `BUILD_GUI_HELPER=0 BUILD_WEBVIEW_AUTH=0` | 27 MiB | 12 |

`libLLVM` alone is 156 MiB of that, pulled in by Mesa for WebKitGTK. The trimmed
image contains no `webkit2gtk` and no Python; `gpclient 2.6.4` runs normally with
`--browser remote`.

### Deliberately not stripped

- **`polkit`** — `gpclient launch-gui` still calls `pkexec` in a trimmed build.
- **`xdg-utils`** — `gpauth` depends on `auth` with `features = ["browser-auth"]`
  unconditionally; only `webview-auth` is a default feature. So `webbrowser`/`open`
  remain compiled and still shell out to `xdg-open` for `--browser <name>`.

Neither appears in the deb's dependency list at all, so they may be removable
separately, but that's a different question from this one.

### Verified

`make init-apk` with three flag combinations, checking the generated `APKBUILD`:

| flags | `depends=` |
| --- | --- |
| *(default)* | all 13 entries — unchanged |
| `BUILD_GUI_HELPER=0` | appindicator + libsecret gone, `webkit2gtk-4.1` retained |
| both `=0` | all three gone |

<details>
<summary>Why <code>depends=</code> is the only thing that needs changing</summary>

`abuild` already derives shared-library dependencies automatically. A trimmed
build's `.PKGINFO` carries `so:libcrypto.so.3`, `so:libgnutls.so.30` and so on
without any help from `depends=`. `scanelf` on the three installed binaries:

```
gpclient:  libz liblz4 libgnutls libp11-kit libhogweed libgmp libssl libcrypto libgcc_s libc.musl
gpservice: (same) + liblzma
gpauth:    libssl libcrypto libgcc_s libc.musl
```

`gpauth` built without the webview links only four libraries, so none of the three
stripped entries are needed by anything the package installs.

This is also why the deb needs less work: `${shlibs:Depends}` derives runtime deps
from linkage, and `libwebkit2gtk-4.1-dev` appears only in `Build-Depends`. The apk's
hand-written `depends=` has no such fallback.

</details>

### Would you want a CLI-only apk as a release artifact?

To be clear about scope: this patch only makes a headless build *expressible*. It
does not publish one, and since nothing in the workflows passes these flags, the
released `.apk` is byte-for-byte what it is today.

If you'd want an official CLI-only artifact, the smallest shape I can see is a
second `docker run` in the existing `apk` job with `-e BUILD_GUI_HELPER=0
-e BUILD_WEBVIEW_AUTH=0`, renaming its output to `…-cli-<arch>.apk` before upload
— no matrix, workflow-input or builder-image changes needed. Happy to open that as
a follow-up if it's of interest; I didn't want to assume you'd want a second
artifact and the support surface that comes with it.

<details>
<summary>Context: why this matters beyond disk usage</summary>

The motivating case is a headless Alpine VM used purely as a VPN gateway, where
`gpclient connect --browser remote` prints a URL opened on another machine — no
X11, no Wayland, no display.

It also blocks Alpine's diskless images, where the root filesystem is tmpfs and
the closure is resident RAM rather than disk: a 1 GiB VM fails the install
outright with `ERROR: failed to extract usr/bin/gpauth: No space left on device`,
filesystem 100% full and `gpclient` never installed.

</details>
