### PR TITLE
chore: merge 2.6.5 release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -421,7 +421,7 @@ jobs:
       if: ${{ matrix.os == 'freebsd' }}
       uses: vmactions/freebsd-vm@v1
       with:
-        release: "14.3"
+        release: "14.4"
         arch: ${{ matrix.arch }}
         usesh: true
         prepare: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "block2",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "2.6.4"
+version = "2.6.5"
 
 [[package]]
 name = "compile-time"
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "gpapi"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "gpauth"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "auth",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "gpclient"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "askama",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "gpgui-helper"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "gpservice"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "openconnect"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "autotools",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.89"
-version = "2.6.4"
+version = "2.6.5"
 authors = ["Kevin Yue <k3vinyue@gmail.com>"]
 homepage = "https://github.com/yuezk/GlobalProtect-openconnect"
 edition = "2024"

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed duplicate tray icons caused by both Tauri configuration and application code creating a tray icon (fix [#464](https://github.com/yuezk/GlobalProtect-openconnect/issues/464)).
+- Fixed a potential crash when VPN progress messages contain printf-style format specifiers.
 
 ## 2.6.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.5
+
+### Fixed
+
+- Fixed duplicate tray icons caused by both Tauri configuration and application code creating a tray icon (fix [#464](https://github.com/yuezk/GlobalProtect-openconnect/issues/464)).
+
 ## 2.6.4
 
 ### Fixed

--- a/crates/openconnect/src/ffi/vpn.c
+++ b/crates/openconnect/src/ffi/vpn.c
@@ -35,7 +35,7 @@ static void print_progress(__attribute__((unused)) void *_vpninfo, int level,
 	if (message == NULL) {
 		ERROR("Failed to format log message");
 	} else {
-		LOG(level, message);
+		vpn_log(level, message);
 		free(message);
 	}
 }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         pname = "globalprotect-openconnect";
         version = cargoToml.workspace.package.version;
-        releaseTag = "v2.6.4";
+        releaseTag = "v2.6.5";
 
         toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 


### PR DESCRIPTION
## Summary

- Merge the published v2.6.5 release changes back into main.

## Main Changes

- Bump the workspace and release metadata to 2.6.5.
- Avoid reformatting preformatted VPN progress messages.
- Build the FreeBSD package on 14.4.

## Verification

- cargo check --workspace --locked
- cargo check -p openconnect --locked
- v2.6.5 release and package workflows passed
