### PR TITLE
fix(macos): make external browser authentication work on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 
 .cargo
 .build
+
+# macOS callback handler build output
+/packaging/macos/build
 SNAPSHOT
 SOURCE_COMMIT
 

--- a/crates/auth/src/browser/browser_auth.rs
+++ b/crates/auth/src/browser/browser_auth.rs
@@ -142,17 +142,58 @@ fn find_browser_path(browser: &Browser) -> String {
 }
 
 fn find_auto_browser_path() -> Option<String> {
-  find_chrome_path().or_else(|| find_program_path("firefox"))
+  find_chrome_path().or_else(find_firefox_path)
 }
 
+#[cfg(not(target_os = "macos"))]
 fn find_chrome_path() -> Option<String> {
   ["google-chrome-stable", "google-chrome", "chromium"]
     .iter()
     .find_map(|browser_name| find_program_path(browser_name))
 }
 
+#[cfg(not(target_os = "macos"))]
+fn find_firefox_path() -> Option<String> {
+  find_program_path("firefox")
+}
+
+#[cfg(not(target_os = "macos"))]
 fn find_program_path(name: &str) -> Option<String> {
   which::which(name).ok().map(|path| path.to_string_lossy().to_string())
+}
+
+/// On macOS browsers ship as app bundles rather than executables on PATH, so
+/// probing for Linux binary names such as `google-chrome` never matches and
+/// `--browser chrome` falls through to the literal string "chrome", which
+/// `/usr/bin/open -a chrome` cannot resolve. `open::with_detached` runs
+/// `/usr/bin/open <url> -a <app>`, which accepts a bundle path.
+#[cfg(target_os = "macos")]
+fn find_chrome_path() -> Option<String> {
+  find_macos_app(&["Google Chrome", "Chromium"])
+}
+
+#[cfg(target_os = "macos")]
+fn find_firefox_path() -> Option<String> {
+  find_macos_app(&["Firefox"])
+}
+
+#[cfg(target_os = "macos")]
+fn find_macos_app(names: &[&str]) -> Option<String> {
+  use std::path::PathBuf;
+
+  let mut dirs = vec![PathBuf::from("/Applications")];
+  if let Some(home) = std::env::var_os("HOME") {
+    dirs.push(PathBuf::from(home).join("Applications"));
+  }
+
+  names.iter().find_map(|name| {
+    let bundle = format!("{}.app", name);
+    dirs
+      .iter()
+      .map(|dir| dir.join(&bundle))
+      .find(|path| path.exists())
+      .map(|path| path.to_string_lossy().to_string())
+  })
 }
 
 async fn wait_auth_data() -> anyhow::Result<SamlAuthData> {
@@ -203,5 +244,11 @@ mod tests {
   fn browser_auto_is_distinct_from_system_default() {
     assert!(matches!(Browser::from_str("auto"), Browser::Auto));
     assert!(matches!(Browser::from_str("default"), Browser::Default));
+  }
+
+  #[cfg(target_os = "macos")]
+  #[test]
+  fn find_macos_app_returns_none_when_bundle_is_absent() {
+    assert!(find_macos_app(&["Definitely Not An Installed Browser"]).is_none());
   }
 }

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,74 @@
+# macOS packaging
+
+## GPCallback.app — handler for the `globalprotectcallback:` URL scheme
+
+External-browser authentication (`gpclient connect --browser`) ends with the
+identity provider redirecting the browser to:
+
+```
+globalprotectcallback:<base64 auth data>
+```
+
+`gpauth` listens on a local socket for that data and records the port in
+`$TMPDIR/gpcallback.port`. Something has to receive the URL from the browser and
+forward it to that socket.
+
+On Linux and BSD that job belongs to `gpgui.desktop`, which claims the scheme with
+`MimeType=x-scheme-handler/globalprotectcallback` and runs `gpclient launch-gui <url>`.
+See `packaging/files/usr/share/applications/gpgui.desktop` and `packaging/bsd/gpgui.desktop`.
+
+macOS had no equivalent. A URL scheme can only be claimed by an application
+bundle, and the macOS build ships bare binaries, so the browser had nowhere to
+deliver the callback — the SSO would complete, the browser would report
+*"Safari cannot open the page because the address is invalid"*, and `gpclient`
+would wait forever.
+
+`GPCallback.app` is that missing hop: a minimal AppleScript applet whose
+`on open location` handler runs `gpclient launch-gui` with the callback URL.
+
+### Build and install
+
+```sh
+./build-gpcallback.sh --install
+```
+
+This builds the bundle into `./build`, installs it to `~/Applications`, and
+registers the scheme with LaunchServices. Verify:
+
+```sh
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -dump | grep globalprotectcallback
+```
+
+Then authenticate normally:
+
+```sh
+sudo gpclient connect <portal> --browser
+```
+
+To remove it:
+
+```sh
+./build-gpcallback.sh --uninstall
+```
+
+### Notes
+
+- Only tools bundled with macOS are used: `osacompile`, `PlistBuddy`, `codesign`,
+  `lsregister`. The compiled `.app` is a build artifact and is not checked in.
+- `gpclient` is looked up in `/opt/homebrew/bin` then `/usr/local/bin`, matching
+  the Apple Silicon and Intel paths in `crates/common/src/constants.rs`.
+- The applet resolves `TMPDIR` with `getconf DARWIN_USER_TEMP_DIR` instead of
+  inheriting it. `do shell script` runs with a minimal environment, and with
+  `TMPDIR` unset Rust's `std::env::temp_dir()` falls back to `/tmp`, where the
+  port file does not live.
+- Handler output goes to `$TMPDIR/gpcallback.log` — the same file `gpauth` points
+  to when the handoff hangs. Check it first when debugging.
+- Testing the handler by hand while a tunnel is already up fails with
+  *"Another instance of the client is already running"*. The single-instance gate
+  in `apps/gpclient/src/cli.rs` exempts only `disconnect`, and the lock file is
+  written by `write_pid_file()` in `apps/gpclient/src/connect/gateway.rs` once the
+  tunnel connects. During a real login the lock does not exist yet, so the
+  callback gets through; disconnect first if you want to test manually.
+- If you only need a one-off connection without installing anything, use
+  `--browser remote`, which prints the URL and reads the callback from stdin.

--- a/packaging/macos/build-gpcallback.sh
+++ b/packaging/macos/build-gpcallback.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Build (and optionally install) GPCallback.app, the macOS handler for the
+# `globalprotectcallback:` URL scheme used by external-browser authentication.
+#
+#   ./build-gpcallback.sh              # build into ./build
+#   ./build-gpcallback.sh --install    # build, install to ~/Applications, register
+#   ./build-gpcallback.sh --uninstall  # remove it again
+#
+# Only tools shipped with macOS are used: osacompile, PlistBuddy, codesign,
+# lsregister. There is nothing to compile and no Rust involvement -- the applet
+# just forwards the callback URL to `gpclient launch-gui`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="$SCRIPT_DIR/gpcallback.applescript"
+BUILD_DIR="${BUILD_DIR:-$SCRIPT_DIR/build}"
+APP_NAME="GPCallback.app"
+APP="$BUILD_DIR/$APP_NAME"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/Applications}"
+BUNDLE_ID="com.yuezk.gpcallback"
+
+PLIST_BUDDY=/usr/libexec/PlistBuddy
+LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "error: this script only applies to macOS" >&2
+  exit 1
+fi
+
+uninstall() {
+  if [ -d "$INSTALL_DIR/$APP_NAME" ]; then
+    rm -rf "${INSTALL_DIR:?}/$APP_NAME"
+    echo "removed $INSTALL_DIR/$APP_NAME"
+  else
+    echo "nothing to remove at $INSTALL_DIR/$APP_NAME"
+  fi
+  "$LSREGISTER" -kill -r -domain local -domain user >/dev/null 2>&1 || true
+  echo "LaunchServices database rebuilt"
+}
+
+build() {
+  rm -rf "$APP"
+  mkdir -p "$BUILD_DIR"
+  osacompile -o "$APP" "$SOURCE"
+
+  local plist="$APP/Contents/Info.plist"
+
+  # Claim the URL scheme. osacompile does not emit CFBundleURLTypes.
+  "$PLIST_BUDDY" -c "Add :CFBundleIdentifier string $BUNDLE_ID" "$plist" 2>/dev/null \
+    || "$PLIST_BUDDY" -c "Set :CFBundleIdentifier $BUNDLE_ID" "$plist"
+  "$PLIST_BUDDY" -c "Add :CFBundleName string GPCallback" "$plist" 2>/dev/null || true
+  # Background-only: no Dock icon, no menu bar takeover during login.
+  "$PLIST_BUDDY" -c "Add :LSUIElement bool true" "$plist" 2>/dev/null || true
+  "$PLIST_BUDDY" -c "Add :CFBundleURLTypes array" "$plist"
+  "$PLIST_BUDDY" -c "Add :CFBundleURLTypes:0:CFBundleURLName string GlobalProtect Callback" "$plist"
+  "$PLIST_BUDDY" -c "Add :CFBundleURLTypes:0:CFBundleTypeRole string Viewer" "$plist"
+  "$PLIST_BUDDY" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$plist"
+  "$PLIST_BUDDY" -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string globalprotectcallback" "$plist"
+
+  # Editing Info.plist invalidates the signature osacompile applied.
+  codesign --force --deep --sign - "$APP"
+
+  echo "built $APP"
+}
+
+install_app() {
+  mkdir -p "$INSTALL_DIR"
+  rm -rf "${INSTALL_DIR:?}/$APP_NAME"
+  cp -R "$APP" "$INSTALL_DIR/"
+
+  # Drop the staging copy before registering the installed one. LaunchServices
+  # picks up bundles on sight, and two apps claiming globalprotectcallback:
+  # makes which one receives the callback non-deterministic.
+  "$LSREGISTER" -u "$APP" >/dev/null 2>&1 || true
+  rm -rf "$APP"
+
+  "$LSREGISTER" -f "$INSTALL_DIR/$APP_NAME"
+  echo "installed $INSTALL_DIR/$APP_NAME and registered the globalprotectcallback: scheme"
+  echo
+  echo "verify with:"
+  echo "  $LSREGISTER -dump | grep globalprotectcallback"
+}
+
+case "${1:-}" in
+  --uninstall) uninstall ;;
+  --install) build; install_app ;;
+  "") build ;;
+  *) echo "usage: $(basename "$0") [--install|--uninstall]" >&2; exit 1 ;;
+esac

--- a/packaging/macos/gpcallback.applescript
+++ b/packaging/macos/gpcallback.applescript
@@ -1,0 +1,42 @@
+-- URL scheme handler for `globalprotectcallback:` on macOS.
+--
+-- The SAML flow ends with the browser being redirected to
+--   globalprotectcallback:<base64 auth data>
+-- On Linux and BSD that scheme is claimed by gpgui.desktop via
+-- `MimeType=x-scheme-handler/globalprotectcallback`, which runs
+-- `gpclient launch-gui <url>`; that reads $TMPDIR/gpcallback.port and writes the
+-- token to the socket gpauth's wait_auth_data() is listening on.
+--
+-- macOS has no equivalent registration, and a URL scheme can only be claimed by
+-- an application bundle, so `gpclient connect --browser` waits forever for a
+-- token that is never delivered. This applet supplies the missing hop.
+--
+-- Notes:
+--  * TMPDIR is resolved with getconf rather than inherited. `do shell script`
+--    runs with a minimal environment, and when TMPDIR is unset Rust's
+--    std::env::temp_dir() falls back to /tmp, where the port file is not.
+--  * Output goes to $TMPDIR/gpcallback.log, the same file wait_auth_data()
+--    points the user at when the handoff hangs.
+--  * gpclient is looked up in both Homebrew prefixes to cover Apple Silicon and
+--    Intel, matching the paths in crates/common/src/constants.rs.
+
+on open location this_URL
+	set shellCmd to "T=$(getconf DARWIN_USER_TEMP_DIR); export TMPDIR=\"$T\"; LOG=\"$T/gpcallback.log\"; " & ¬
+		"GPCLIENT=''; for p in /opt/homebrew/bin/gpclient /usr/local/bin/gpclient; do " & ¬
+		"if [ -x \"$p\" ]; then GPCLIENT=\"$p\"; break; fi; done; " & ¬
+		"if [ -z \"$GPCLIENT\" ]; then echo \"$(date): gpclient not found in /opt/homebrew/bin or /usr/local/bin\" >>\"$LOG\"; exit 1; fi; " & ¬
+		"\"$GPCLIENT\" launch-gui " & quoted form of this_URL & " >>\"$LOG\" 2>&1"
+
+	try
+		do shell script shellCmd
+	on error errMsg number errNum
+		-- Never raise a modal dialog in the middle of a login; log and move on.
+		set logLine to (do shell script "date") & ": gpcallback handler error " & errNum & ": " & errMsg
+		do shell script "echo " & quoted form of logLine & " >> \"$(getconf DARWIN_USER_TEMP_DIR)/gpcallback.log\""
+	end try
+end open location
+
+-- Opened without a URL (double-clicked, or launched by LaunchServices during
+-- registration): do nothing rather than fail.
+on run
+end run


### PR DESCRIPTION
## Problem

On macOS `gpclient connect --browser` never completes: SSO finishes, the portal renders
"Authentication Complete", and the client hangs. The browser reports *"the address is
invalid"*.

## Cause

The flow ends by redirecting to `globalprotectcallback:<data>`. `wait_auth_data()` waits for
it on a local socket, recording the port in `$TMPDIR/gpcallback.port`. On Linux/BSD
`gpgui.desktop` claims the scheme and forwards the URL via `gpclient launch-gui`. macOS has
no equivalent — a URL scheme can only be claimed by an app bundle, and the macOS build ships
bare binaries — so the token is never delivered.

(#432 and #589 are the same symptom on Linux from a missing `.desktop` association; on macOS
there is none to begin with.)

Separately, `find_chrome_path()` probes `PATH` for `google-chrome`/`chromium` (and
`firefox`), which never match on macOS where browsers are `.app` bundles. `--browser` auto
silently fell back to the system default; `--browser chrome` failed outright, since it
passes the literal `"chrome"` to `open -a`, which cannot resolve it.

## Changes

- **`packaging/macos/`** — AppleScript applet whose `on open location` forwards the URL to
  `gpclient launch-gui`, plus `build-gpcallback.sh --install|--uninstall` and a README.
  Stock tooling only (`osacompile`, `PlistBuddy`, `codesign`, `lsregister`); no new
  dependency. The built `.app` is gitignored.
- **`browser_auth.rs`** — per-platform browser lookup; on macOS probe `/Applications` and
  `~/Applications` for the bundle path `open -a` accepts.

Three non-obvious bits: the applet resolves `TMPDIR` via `getconf DARWIN_USER_TEMP_DIR`
(`do shell script` runs with a minimal environment, and `temp_dir()` would fall back to
`/tmp`); `gpclient` is looked up in both Homebrew prefixes per `constants.rs`; and install
removes the staging copy first, since two bundles claiming the scheme makes delivery
non-deterministic.

## Testing

`cargo check`, `cargo test -p auth --features browser-auth`, `cargo fmt --check` clean.
Verified end to end on macOS 26.6 (Apple Silicon) against a live SAML + RSA SecurID/Duo
portal: `--browser` now completes the handoff unattended and brings up the tunnel. Linux and
BSD are untouched; there is no macOS job in CI, so none was added.

Out of scope, for context: on the same portal the embedded WKWebView fails at the Duo
callback with "Unable to complete authentication…" while a real browser succeeds — that is
what made external-browser auth necessary here. Happy to file separately.
