### PR TITLE
ci: build and publish headless (GUI-free) apk and deb variants

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,6 +180,80 @@ jobs:
         path: |
           build-gp-${{ matrix.package }}/artifacts/*
 
+  # GUI-free variant, for the headless servers README.md names as the audience
+  # for `--browser remote`. Same source and same builder images as build-gp;
+  # only the three GUI flags differ, which #638 made effective for `depends=`.
+  #
+  # Scoped to apk and deb: those are the two formats whose depends= is gated on
+  # the flags today (Makefile `init-apk` / `init-debian`). An rpm built this way
+  # would still declare the GUI dependencies, so a "CLI" rpm would mislead.
+  build-gp-headless:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    needs:
+    - tarball
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: ubuntu-24.04-arm
+        package: [apk, deb]
+    runs-on: ${{ matrix.os.runner }}
+    name: build-gp-headless (${{ matrix.package }}, ${{ matrix.os.arch }})
+    steps:
+    - name: Prepare workspace
+      run: |
+        rm -rf build-gp-headless-${{ matrix.package }}
+        mkdir -p build-gp-headless-${{ matrix.package }}
+    - name: Download tarball
+      uses: actions/download-artifact@v8
+      with:
+        name: artifact-source
+        path: build-gp-headless-${{ matrix.package }}
+    - name: Build GUI-free ${{ matrix.package }} package in Docker
+      run: |
+        docker run --rm \
+          -e COREPACK_INTEGRITY_KEYS=0 \
+          -e LIBXML2_STATIC=1 \
+          -e INCLUDE_GUI=0 \
+          -e BUILD_GUI_HELPER=0 \
+          -e BUILD_WEBVIEW_AUTH=0 \
+          -v $(pwd)/build-gp-headless-${{ matrix.package }}:/workspace \
+          yuezk/gpdev:${{ matrix.package }}-builder-tauri2
+    # Not `bash install.sh`: that script checks `gpgui-helper --version`
+    # unconditionally, and BUILD_GUI_HELPER=0 means it isn't built. Its
+    # GPGUI_INSTALLED knob covers gpgui but not the helper. Rather than ask for
+    # a new knob in the builder image, this asserts the property that actually
+    # matters for the variant — the CLI binaries work and no GUI binary shipped.
+    - name: Verify GUI-free ${{ matrix.package }} package in Docker
+      run: |
+        docker run --rm \
+          -e COREPACK_INTEGRITY_KEYS=0 \
+          -v $(pwd)/build-gp-headless-${{ matrix.package }}:/workspace \
+          --entrypoint /bin/bash \
+          yuezk/gpdev:${{ matrix.package }}-builder-tauri2 -lc '
+            set -eux
+            if command -v apk >/dev/null; then
+              sudo apk add --allow-untrusted /workspace/artifacts/*.apk
+            else
+              sudo apt-get install -y /workspace/artifacts/*.deb
+            fi
+            gpclient --version
+            gpservice --version
+            gpauth --version
+            ! command -v gpgui-helper
+            ! command -v gpgui
+          '
+    - name: Upload GUI-free ${{ matrix.package }} package
+      uses: actions/upload-artifact@v7
+      with:
+        name: artifact-gp-headless-${{ matrix.package }}-${{ matrix.os.arch }}
+        if-no-files-found: error
+        path: |
+          build-gp-headless-${{ matrix.package }}/artifacts/*
+
   build-docker-image:
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,11 @@ on:
         description: 'Build binary package'
         required: true
         default: true
+      release-headless:
+        type: boolean
+        description: 'Also build headless (GUI-free) apk and deb variants'
+        required: true
+        default: true
       release-docker:
         type: boolean
         description: 'Publish Docker image'
@@ -73,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.result }}
+      headless-matrix: ${{ steps.set-headless-matrix.outputs.result }}
     steps:
     - name: Set up matrix
       id: set-matrix
@@ -88,13 +94,39 @@ jobs:
             "arm64": ["ubuntu-24.04-arm"]
           }
 
+          // release-headless is a build VARIANT, not a package format — excluded
+          // here like release-docker, and handled by the build-headless job.
           const package = Object.entries(inputs)
-            .filter(([key, value]) => key.startsWith('release-') && key !== 'release-docker' && value)
+            .filter(([key, value]) => key.startsWith('release-')
+              && key !== 'release-docker' && key !== 'release-headless' && value)
             .map(([key, value]) => key.replace('release-', ''))
 
           return JSON.stringify({
             os: osMap[arch],
             package,
+          })
+
+    - name: Set up headless matrix
+      id: set-headless-matrix
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        script: |
+          const inputs = ${{ toJson(inputs) }}
+          const { arch } = inputs
+          const osMap = {
+            "all": ["ubuntu-latest", "ubuntu-24.04-arm"],
+            "x86_64": ["ubuntu-latest"],
+            "arm64": ["ubuntu-24.04-arm"]
+          }
+
+          // apk and deb only: their depends= is gated on the GUI flags
+          // (Makefile init-apk / init-debian). The rpm spec declares
+          // `Requires: (libappindicator-gtk3 or libayatana-appindicator)`
+          // unconditionally, so a headless rpm would still pull GUI deps.
+          return JSON.stringify({
+            os: osMap[arch],
+            package: ["apk", "deb"],
           })
 
   build:
@@ -141,6 +173,71 @@ jobs:
         if-no-files-found: error
         path: |
           build-${{ matrix.package }}/artifacts/*
+
+  # GUI-free variant of the same packages, for the headless servers README.md
+  # names as the audience for `--browser remote`. Identical to `build` above
+  # except for the three GUI flags and the verification step.
+  build-headless:
+    if: ${{ inputs.release-headless }}
+    needs:
+    - setup-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.headless-matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Prepare workspace
+      run: rm -rf build-headless-${{ matrix.package }} && mkdir -p build-headless-${{ matrix.package }}
+
+    - name: Download ${{ inputs.tag }} source code
+      env:
+        GH_TOKEN: ${{ secrets.GH_PAT }}
+      run: |
+        gh -R yuezk/GlobalProtect-openconnect \
+          release download ${{ inputs.tag }} \
+          --pattern '*[^offline].tar.gz' \
+          --dir build-headless-${{ matrix.package }}
+
+    - name: Build GUI-free ${{ matrix.package }} package in Docker
+      run: |
+        docker run --rm \
+          -v $(pwd)/build-headless-${{ matrix.package }}:/workspace \
+          -e COREPACK_INTEGRITY_KEYS=0 \
+          -e LIBXML2_STATIC=1 \
+          -e INCLUDE_GUI=0 \
+          -e BUILD_GUI_HELPER=0 \
+          -e BUILD_WEBVIEW_AUTH=0 \
+          yuezk/gpdev:${{ matrix.package }}-builder-tauri2
+
+    # Not `bash install.sh`: it runs `gpgui-helper --version` unconditionally,
+    # and BUILD_GUI_HELPER=0 means it isn't built. Assert the variant's own
+    # contract instead — the CLI binaries work, no GUI binary shipped.
+    - name: Verify GUI-free ${{ matrix.package }} package in Docker
+      run: |
+        docker run --rm \
+          -e COREPACK_INTEGRITY_KEYS=0 \
+          -v $(pwd)/build-headless-${{ matrix.package }}:/workspace \
+          --entrypoint /bin/bash \
+          yuezk/gpdev:${{ matrix.package }}-builder-tauri2 -lc '
+            set -eux
+            if command -v apk >/dev/null; then
+              sudo apk add --allow-untrusted /workspace/artifacts/*.apk
+            else
+              sudo apt-get install -y /workspace/artifacts/*.deb
+            fi
+            gpclient --version
+            gpservice --version
+            gpauth --version
+            ! command -v gpgui-helper
+            ! command -v gpgui
+          '
+
+    - name: Upload GUI-free ${{ matrix.package }} package
+      uses: actions/upload-artifact@v7
+      with:
+        name: artifact-headless-${{ matrix.os }}-${{ matrix.package }}
+        if-no-files-found: error
+        path: |
+          build-headless-${{ matrix.package }}/artifacts/*
 
   build-docker-image:
     needs:
@@ -249,8 +346,12 @@ jobs:
   gh-release:
     needs:
     - build
+    - build-headless
     runs-on: ubuntu-latest
-    if: ${{ inputs.gh-release }}
+    # always(): build-headless is skipped when release-headless is false, and a
+    # skipped dependency would otherwise skip this job too. `build` must still
+    # have succeeded.
+    if: ${{ always() && inputs.gh-release && needs.build.result == 'success' }}
     permissions:
       actions: read
       contents: read
@@ -288,6 +389,29 @@ jobs:
         done
         for file in gh-release/artifact-ubuntu-24.04-arm-apk/*.apk; do
           mv "$file" "${file%.apk}-aarch64.apk"
+        done
+    # The CLI variant builds from the same source, so it produces byte-identical
+    # FILENAMES to the GUI packages. Without a distinguishing suffix the two
+    # would collide as release assets. Suffix, not a different pkgname: these
+    # are files rather than repository entries, so `apk add ./<file>` /
+    # `apt install ./<file>` picks whichever the user wants, and upgrades
+    # between the two work as normal.
+    - name: Rename GUI-free artifacts
+      if: ${{ inputs.release-headless }}
+      run: |
+        shopt -s nullglob
+
+        for file in gh-release/artifact-headless-ubuntu-latest-apk/*.apk; do
+          mv "$file" "${file%.apk}-headless-x86_64.apk"
+        done
+        for file in gh-release/artifact-headless-ubuntu-24.04-arm-apk/*.apk; do
+          mv "$file" "${file%.apk}-headless-aarch64.apk"
+        done
+        for file in gh-release/artifact-headless-ubuntu-latest-deb/*.deb; do
+          mv "$file" "${file%.deb}-headless.deb"
+        done
+        for file in gh-release/artifact-headless-ubuntu-24.04-arm-deb/*.deb; do
+          mv "$file" "${file%.deb}-headless.deb"
         done
     - name: Generate release asset checksums
       id: release-assets


### PR DESCRIPTION
Builds and publishes a headless (GUI-free) variant of the existing packages, for the headless servers `README.md` already names as the audience for `--browser remote`.

Today every published package pulls the full webview closure. Both figures below come from the two artifacts of a single CI run, installed the same way into fresh `alpine:3.23` aarch64 containers on top of `nftables iproute2 ca-certificates curl`:

| build | installed | packages |
| --- | --- | --- |
| current | 569 MiB | 214 |
| `INCLUDE_GUI=0 BUILD_GUI_HELPER=0 BUILD_WEBVIEW_AUTH=0` | **56 MiB** | **43** |

The 171 packages that disappear are the GUI closure — `webkit2gtk-4.1`, `libayatana-appindicator`, `libsecret` and everything they drag in. On a headless box none of it is ever loaded, but it is all installed, and on a VPN gateway that is surface worth not having.

The flags already exist, and #638 made them effective for the package `depends=` — so this doesn't add a build mode, it publishes one the build can already express.

### What it changes

- **`build.yaml`** — a `build-gp-headless` job, for CI coverage on every push.
- **`release.yaml`** — a `build-headless` job behind a new `release-headless` input (default true), plus a rename so the assets don't collide: both variants otherwise produce identical filenames.

`release-headless` is excluded from the `setup-matrix` package filter alongside `release-docker`, since it selects a build variant rather than a package format.

### Scope

apk and deb only — the two formats whose `depends=` is gated on the flags today (`init-apk` / `init-debian`). The rpm spec declares `Requires: (libappindicator-gtk3 or libayatana-appindicator)` unconditionally and isn't flag-gated, so a headless rpm would still pull GUI dependencies. Happy to add it if the spec gets the same treatment.

No `provides`/`replaces` handling: these are release assets rather than repository entries, so a same-`pkgname` variant is just a different file to `apk add ./…` / `apt install ./…`. AUR and PPA are untouched.

### On the verification step

It doesn't reuse `install.sh`, which runs `gpgui-helper --version` unconditionally — `BUILD_GUI_HELPER=0` means it isn't built, and the `GPGUI_INSTALLED` knob covers `gpgui` but not the helper. Rather than ask for a new knob in the builder image, the step asserts the variant's contract directly: the three CLI binaries run, and neither GUI binary shipped.

`polkit` and `xdg-utils` are deliberately still declared — `launch-gui` shells out to `pkexec`, and `--browser default` uses `xdg-open`, so both remain reachable in a GUI-free build.

### Tested on a fork

**`build.yaml`** — 4/4 green, both arches, both formats, including the verify step: https://github.com/rhoetsc/GlobalProtect-openconnect/actions/runs/31195851883 (the two apks measured above are that run's artifacts).

**`release.yaml`** — dispatched against `v2.6.4` with only `release-headless=true`: https://github.com/rhoetsc/GlobalProtect-openconnect/actions/runs/31302472025 — `check`, `setup-matrix`, source download, build, verify and upload all green, producing `artifact-headless-…-apk` (8.72 MB) and `-deb` (3.84 MB).

### Note

Kept as separate jobs rather than a `variant` axis on the existing matrices, so they can't affect the current pipeline. Happy to fold them in instead — or to close this if you'd rather not carry another published artifact.
