### PR TITLE
feat: add --log-format json to gpclient and gpauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,17 @@ Commands:
   connect     Connect to a portal server
   disconnect  Disconnect from the server
   launch-gui  Launch the GUI
+  hip         Generate HIP report
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-      --fix-openssl        Get around the OpenSSL 'unsafe legacy renegotiation' error
-      --ignore-tls-errors  Ignore TLS errors
-  -h, --help               Print help
-  -V, --version            Print version
+      --fix-openssl              Uses extended compatibility mode for OpenSSL operations to support a broader range of systems and formats.
+      --ignore-tls-errors        Ignore the TLS errors
+      --log-format <LOG_FORMAT>  The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. [default: text] [possible values: text, json]
+  -v, --verbose...               Enable verbose output, -v for debug, -vv for trace
+  -q, --quiet...                 Decrease logging verbosity, -q for warnings, -qq for errors
+  -h, --help                     Print help (see more with '--help')
+  -V, --version                  Print version
 ```
 
 > **Tip:** Use `gpclient help <command>` for detailed information on a specific command.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Commands:
 Options:
       --fix-openssl              Uses extended compatibility mode for OpenSSL operations to support a broader range of systems and formats.
       --ignore-tls-errors        Ignore the TLS errors
-      --log-format <LOG_FORMAT>  The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. [default: text] [possible values: text, json]
+      --log-format <LOG_FORMAT>  Log output format. JSON is intended for non-interactive consumers; interactive prompts remain text. [default: text] [possible values: text, json]
   -v, --verbose...               Enable verbose output, -v for debug, -vv for trace
   -q, --quiet...                 Decrease logging verbosity, -q for warnings, -qq for errors
   -h, --help                     Print help (see more with '--help')

--- a/apps/gpauth/src/cli.rs
+++ b/apps/gpauth/src/cli.rs
@@ -81,7 +81,7 @@ struct Cli {
     long,
     value_enum,
     default_value_t = LogFormat::Text,
-    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. Interactive prompts are not JSON, so json suits non-interactive runs."
+    help = "Log output format. JSON is intended for non-interactive consumers; interactive prompts remain text."
   )]
   log_format: LogFormat,
 

--- a/apps/gpauth/src/cli.rs
+++ b/apps/gpauth/src/cli.rs
@@ -4,6 +4,7 @@ use gpapi::{
   auth::{SamlAuthData, SamlAuthResult},
   clap::{Args, InfoLevelVerbosity, args::Os, handle_error},
   gp_params::GpParams,
+  log_format::{LogFormat, write_json_record},
   os_profile::{ClientOs, OsProfile},
   utils::{normalize_server, openssl},
 };
@@ -76,6 +77,14 @@ struct Cli {
   #[arg(long, help = "Ignore TLS errors")]
   ignore_tls_errors: bool,
 
+  #[arg(
+    long,
+    value_enum,
+    default_value_t = LogFormat::Text,
+    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text."
+  )]
+  log_format: LogFormat,
+
   #[cfg(feature = "webview-auth")]
   #[arg(long, help = "Use the default browser for authentication")]
   default_browser: bool,
@@ -107,6 +116,10 @@ impl Args for Cli {
 
   fn ignore_tls_errors(&self) -> bool {
     self.ignore_tls_errors
+  }
+
+  fn log_format(&self) -> LogFormat {
+    self.log_format
   }
 }
 
@@ -205,16 +218,23 @@ impl Cli {
   }
 }
 
-fn init_logger(cli: &Cli) {
-  env_logger::builder()
-    .filter_level(cli.verbose.log_level_filter())
-    .init();
+fn build_logger(cli: &Cli) -> env_logger::Builder {
+  let mut builder = env_logger::builder();
+  builder.filter_level(cli.verbose.log_level_filter());
+
+  // Text is env_logger's own format, so leave it untouched rather than
+  // reimplementing it.
+  if cli.log_format == LogFormat::Json {
+    builder.format(write_json_record);
+  }
+
+  builder
 }
 
 pub async fn run() {
   let cli = Cli::parse();
 
-  init_logger(&cli);
+  build_logger(&cli).init();
   info!("gpauth started: {}", VERSION);
 
   if let Err(err) = cli.run().await {
@@ -240,7 +260,79 @@ pub fn print_auth_result(auth_result: anyhow::Result<SamlAuthData>, host_id: Opt
 
 #[cfg(test)]
 mod tests {
+  use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+  };
+
+  use log::Log;
+
   use super::*;
+
+  /// gpauth's own result already goes to stdout as JSON; this makes its *logs*
+  /// readable the same way, so a caller driving it does not have to parse prose
+  /// on stderr to find out why an attempt failed.
+  #[test]
+  fn log_format_defaults_to_text() {
+    let cli = Cli::try_parse_from(["gpauth", "portal.example.com"]).expect("gpauth args should parse");
+
+    assert_eq!(cli.log_format, LogFormat::Text);
+  }
+
+  #[test]
+  fn log_format_accepts_json() {
+    let cli =
+      Cli::try_parse_from(["gpauth", "portal.example.com", "--log-format", "json"]).expect("gpauth args should parse");
+
+    assert_eq!(cli.log_format, LogFormat::Json);
+  }
+
+  /// A `Write` that keeps what was written, so the logger can be driven for
+  /// real instead of asserting on how it was configured.
+  #[derive(Clone, Default)]
+  struct Captured(Arc<Mutex<Vec<u8>>>);
+
+  impl Write for Captured {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+      self.0.lock().unwrap().extend_from_slice(buf);
+      Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+      Ok(())
+    }
+  }
+
+  #[test]
+  fn json_format_emits_one_json_object_per_record() {
+    let cli =
+      Cli::try_parse_from(["gpauth", "portal.example.com", "--log-format", "json"]).expect("gpauth args should parse");
+
+    let captured = Captured::default();
+    let logger = build_logger(&cli)
+      .target(env_logger::Target::Pipe(Box::new(captured.clone())))
+      .build();
+
+    // Drive the logger directly: `init()` installs a global that a second test
+    // could not replace.
+    logger.log(
+      &log::Record::builder()
+        .level(log::Level::Info)
+        .target("gpauth")
+        .args(format_args!("authenticating against {}", "portal.example.com"))
+        .build(),
+    );
+    logger.flush();
+
+    let out = String::from_utf8(captured.0.lock().unwrap().clone()).expect("log output should be UTF-8");
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "expected exactly one line, got: {out:?}");
+
+    let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap_or_else(|e| panic!("not JSON: {out:?} ({e})"));
+    assert_eq!(v["level"], "INFO");
+    assert_eq!(v["target"], "gpauth");
+    assert_eq!(v["message"], "authenticating against portal.example.com");
+  }
 
   #[test]
   fn os_defaults_to_runtime_os() {

--- a/apps/gpauth/src/cli.rs
+++ b/apps/gpauth/src/cli.rs
@@ -81,7 +81,7 @@ struct Cli {
     long,
     value_enum,
     default_value_t = LogFormat::Text,
-    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text."
+    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. Interactive prompts are not JSON, so json suits non-interactive runs."
   )]
   log_format: LogFormat,
 

--- a/apps/gpclient/src/cli.rs
+++ b/apps/gpclient/src/cli.rs
@@ -82,7 +82,7 @@ struct Cli {
     long,
     value_enum,
     default_value_t = LogFormat::Text,
-    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. Interactive prompts are not JSON, so json suits non-interactive runs."
+    help = "Log output format. JSON is intended for non-interactive consumers; interactive prompts remain text."
   )]
   log_format: LogFormat,
 

--- a/apps/gpclient/src/cli.rs
+++ b/apps/gpclient/src/cli.rs
@@ -82,7 +82,7 @@ struct Cli {
     long,
     value_enum,
     default_value_t = LogFormat::Text,
-    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text."
+    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text. Interactive prompts are not JSON, so json suits non-interactive runs."
   )]
   log_format: LogFormat,
 

--- a/apps/gpclient/src/cli.rs
+++ b/apps/gpclient/src/cli.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use clap::{Parser, Subcommand};
 use gpapi::{
   clap::{Args, InfoLevelVerbosity, handle_error},
+  log_format::{LogFormat, write_json_record},
   utils::openssl,
 };
 use log::info;
@@ -32,6 +33,7 @@ pub(crate) struct SharedArgs<'a> {
   pub(crate) fix_openssl: bool,
   pub(crate) ignore_tls_errors: bool,
   pub(crate) verbose: &'a InfoLevelVerbosity,
+  pub(crate) log_format: LogFormat,
 }
 
 #[derive(Subcommand)]
@@ -76,6 +78,14 @@ struct Cli {
   #[arg(long, help = "Ignore the TLS errors")]
   ignore_tls_errors: bool,
 
+  #[arg(
+    long,
+    value_enum,
+    default_value_t = LogFormat::Text,
+    help = "The log output format. Use 'json' when another program reads the logs, so it can match on fields rather than on message text."
+  )]
+  log_format: LogFormat,
+
   #[command(flatten)]
   verbose: InfoLevelVerbosity,
 }
@@ -87,6 +97,10 @@ impl Args for Cli {
 
   fn ignore_tls_errors(&self) -> bool {
     self.ignore_tls_errors
+  }
+
+  fn log_format(&self) -> LogFormat {
+    self.log_format
   }
 }
 
@@ -132,6 +146,7 @@ impl Cli {
       fix_openssl: self.fix_openssl,
       ignore_tls_errors: self.ignore_tls_errors,
       verbose: &self.verbose,
+      log_format: self.log_format,
     };
 
     if self.ignore_tls_errors {
@@ -147,9 +162,15 @@ impl Cli {
   }
 }
 
-fn init_logger(cli: &Cli) {
+fn build_logger(cli: &Cli) -> env_logger::Builder {
   let mut builder = env_logger::builder();
   builder.filter_level(cli.verbose.log_level_filter());
+
+  // Text is env_logger's own format, so leave it untouched rather than
+  // reimplementing it.
+  if cli.log_format == LogFormat::Json {
+    builder.format(write_json_record);
+  }
 
   // Output the log messages to a file if the command is the auth callback
   if let CliCommand::LaunchGui(args) = &cli.command {
@@ -162,18 +183,131 @@ fn init_logger(cli: &Cli) {
     }
   }
 
-  builder.init();
+  builder
 }
 
 pub(crate) async fn run() {
   let cli = Cli::parse();
 
-  init_logger(&cli);
+  build_logger(&cli).init();
 
   info!("gpclient started: {}", VERSION);
 
   if let Err(err) = cli.run().await {
     handle_error(err, &cli);
     std::process::exit(1);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+  };
+
+  use log::Log;
+
+  use super::*;
+
+  fn parse_cli(args: &[&str]) -> Cli {
+    Cli::try_parse_from(args).expect("arguments should parse")
+  }
+
+  /// Text stays the default: a plain `gpclient connect` must keep the output it
+  /// has always had, or every existing user's terminal changes under them.
+  #[test]
+  fn log_format_defaults_to_text() {
+    assert_eq!(parse_cli(&["gpclient", "disconnect"]).log_format, LogFormat::Text);
+  }
+
+  #[test]
+  fn log_format_accepts_json() {
+    assert_eq!(
+      parse_cli(&["gpclient", "--log-format", "json", "disconnect"]).log_format,
+      LogFormat::Json
+    );
+  }
+
+  /// An unknown value is a mistake worth reporting rather than silently
+  /// falling back to text, which would leave a caller parsing prose.
+  #[test]
+  fn log_format_rejects_an_unknown_value() {
+    // `.err()` rather than `unwrap_err()`: the Ok side is `Cli`, which is not
+    // `Debug`, and it is not worth deriving it just to print an error we expect.
+    let err = Cli::try_parse_from(["gpclient", "--log-format", "yaml", "disconnect"])
+      .err()
+      .expect("an unknown log format should be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("yaml"), "error should name the input: {msg}");
+    assert!(msg.contains("json"), "error should list the valid values: {msg}");
+  }
+
+  /// A `Write` that keeps what was written, so the logger can be driven for
+  /// real instead of asserting on how it was configured.
+  #[derive(Clone, Default)]
+  struct Captured(Arc<Mutex<Vec<u8>>>);
+
+  impl Captured {
+    fn contents(&self) -> String {
+      String::from_utf8(self.0.lock().unwrap().clone()).expect("log output should be UTF-8")
+    }
+  }
+
+  impl Write for Captured {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+      self.0.lock().unwrap().extend_from_slice(buf);
+      Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+      Ok(())
+    }
+  }
+
+  fn log_one_record(args: &[&str]) -> String {
+    let captured = Captured::default();
+    let logger = build_logger(&parse_cli(args))
+      .target(env_logger::Target::Pipe(Box::new(captured.clone())))
+      .build();
+
+    // Drive the logger directly: `init()` installs a global that a second test
+    // could not replace.
+    logger.log(
+      &log::Record::builder()
+        .level(log::Level::Info)
+        .target("gpclient")
+        .args(format_args!("connected to {}", "vpn.example.com"))
+        .build(),
+    );
+    logger.flush();
+
+    captured.contents()
+  }
+
+  /// The point of the flag: with `json`, a caller gets fields, and gets them one
+  /// record per line so the stream can be read incrementally.
+  #[test]
+  fn json_format_emits_one_json_object_per_record() {
+    let out = log_one_record(&["gpclient", "--log-format", "json", "disconnect"]);
+
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "expected exactly one line, got: {out:?}");
+
+    let v: serde_json::Value = serde_json::from_str(lines[0]).unwrap_or_else(|e| panic!("not JSON: {out:?} ({e})"));
+    assert_eq!(v["level"], "INFO");
+    assert_eq!(v["target"], "gpclient");
+    assert_eq!(v["message"], "connected to vpn.example.com");
+  }
+
+  #[test]
+  fn text_format_is_left_alone() {
+    let out = log_one_record(&["gpclient", "disconnect"]);
+
+    assert!(out.contains("connected to vpn.example.com"), "message missing: {out:?}");
+    assert!(
+      serde_json::from_str::<serde_json::Value>(out.trim()).is_err(),
+      "text output should not be JSON: {out:?}"
+    );
   }
 }

--- a/apps/gpclient/src/connect/credential.rs
+++ b/apps/gpclient/src/connect/credential.rs
@@ -85,6 +85,7 @@ impl ConnectHandler<'_> {
           .sslkey(self.args.sslkey.as_deref())
           .key_password(key_password.as_deref())
           .browser(browser)
+          .log_format(self.shared_args.log_format)
           .verbose(verbose);
 
         #[cfg(feature = "webview-auth")]

--- a/apps/gpclient/src/connect/gateway.rs
+++ b/apps/gpclient/src/connect/gateway.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use gpapi::{
+  clap::report,
   cookie_store,
   credential::{AuthCookieCredential, Credential},
   gateway::{GatewayLogin, GatewayLoginContext, SessionExtensionAuth, gateway_login, gateway_login_with_context},
@@ -17,7 +18,7 @@ use gpapi::{
   utils::shutdown_signal,
 };
 use inquire::Text;
-use log::{info, warn};
+use log::{Level, info, warn};
 use openconnect::{Vpn, VpnBuilder};
 use tokio::{runtime::Handle, task::JoinHandle};
 
@@ -281,9 +282,22 @@ impl ConnectHandler<'_> {
       return;
     }
 
-    eprintln!("\nNOTE: Gateway authentication failed after portal login.");
-    eprintln!("NOTE: If this server also accepts direct gateway login, try:");
-    eprintln!("NOTE: {}", direct_gateway_command(gateway));
+    let format = self.shared_args.log_format;
+    report(
+      format,
+      Level::Warn,
+      "\nNOTE: Gateway authentication failed after portal login.",
+    );
+    report(
+      format,
+      Level::Warn,
+      "NOTE: If this server also accepts direct gateway login, try:",
+    );
+    report(
+      format,
+      Level::Warn,
+      &format!("NOTE: {}", direct_gateway_command(gateway)),
+    );
   }
 
   async fn login_gateway(
@@ -384,6 +398,7 @@ impl ConnectHandler<'_> {
       vpn_clone.disconnect();
     });
 
+    let log_format = self.shared_args.log_format;
     let connect_result = vpn.connect(move |vpn_session_info| {
       tunnel_established_on_connect.store(true, Ordering::SeqCst);
       write_pid_file();
@@ -394,7 +409,7 @@ impl ConnectHandler<'_> {
       let session_info = session_info_from_vpn(vpn_session_info, allow_extend_session);
       info!("VPN session info: {}", session_info.log_summary());
 
-      let task = spawn_session_runtime_with_info(&runtime_handle, session_ctx, session_info);
+      let task = spawn_session_runtime_with_info(&runtime_handle, session_ctx, session_info, log_format);
       session_task_on_connect.lock().unwrap().replace(task);
     });
     let tunnel_established = tunnel_established.load(Ordering::SeqCst);

--- a/apps/gpclient/src/connect/mod.rs
+++ b/apps/gpclient/src/connect/mod.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 
 use anyhow::bail;
 use gpapi::{
+  clap::report,
   error::PortalError,
   gateway::{GatewayLoginContext, GatewaySelection},
   gp_params::GpParams,
@@ -14,7 +15,7 @@ use gpapi::{
   utils::request::RequestIdentityError,
 };
 use inquire::{Password, PasswordDisplayMode, Select};
-use log::{info, warn};
+use log::{Level, info, warn};
 
 use crate::cli::SharedArgs;
 
@@ -110,8 +111,17 @@ impl<'a> ConnectHandler<'a> {
 
       match root_cause {
         RequestIdentityError::NoKey => {
-          eprintln!("ERROR: No private key found in the certificate file");
-          eprintln!("ERROR: Please provide the private key file using the `-k` option");
+          let format = self.shared_args.log_format;
+          report(
+            format,
+            Level::Error,
+            "ERROR: No private key found in the certificate file",
+          );
+          report(
+            format,
+            Level::Error,
+            "ERROR: Please provide the private key file using the `-k` option",
+          );
           return Ok(());
         }
         RequestIdentityError::NoPassphrase(cert_type) | RequestIdentityError::DecryptError(cert_type) => {
@@ -153,8 +163,17 @@ impl<'a> ConnectHandler<'a> {
       info!("Trying the gateway authentication workflow...");
       self.connect_gateway_with_prelogin(server, server, false, None).await?;
 
-      eprintln!("\nNOTE: the server may be a gateway, not a portal.");
-      eprintln!("NOTE: try to use the `--as-gateway` option if you were authenticated twice.");
+      let format = self.shared_args.log_format;
+      report(
+        format,
+        Level::Warn,
+        "\nNOTE: the server may be a gateway, not a portal.",
+      );
+      report(
+        format,
+        Level::Warn,
+        "NOTE: try to use the `--as-gateway` option if you were authenticated twice.",
+      );
 
       Ok(())
     } else {

--- a/apps/gpclient/src/session.rs
+++ b/apps/gpclient/src/session.rs
@@ -1,11 +1,13 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use gpapi::{
+  clap::report,
   gateway::{SessionContext, SessionExtensionAuth, extend_session},
+  log_format::LogFormat,
   os_profile::OsProfile,
   session::{SessionInfo, SessionRequestArgs, SessionWarning},
 };
-use log::{info, warn};
+use log::{Level, info, warn};
 use openconnect::VpnSessionInfo;
 use tokio::{runtime::Handle, task::JoinHandle};
 
@@ -59,11 +61,12 @@ pub(crate) fn spawn_session_runtime_with_info(
   handle: &Handle,
   session_ctx: SessionContext,
   session_info: SessionInfo,
+  log_format: LogFormat,
 ) -> JoinHandle<()> {
-  handle.spawn(run_session_runtime(session_ctx, session_info))
+  handle.spawn(run_session_runtime(session_ctx, session_info, log_format))
 }
 
-async fn run_session_runtime(session_ctx: SessionContext, mut session_info: SessionInfo) {
+async fn run_session_runtime(session_ctx: SessionContext, mut session_info: SessionInfo, log_format: LogFormat) {
   loop {
     let Some(schedule) = build_session_warning_schedule(&session_info) else {
       info!("No session warning schedule provided by the gateway");
@@ -72,7 +75,7 @@ async fn run_session_runtime(session_ctx: SessionContext, mut session_info: Sess
 
     tokio::time::sleep(schedule.delay).await;
 
-    eprintln!("\nWARNING: {}", schedule.message);
+    report(log_format, Level::Warn, &format!("\nWARNING: {}", schedule.message));
 
     if !schedule.should_auto_extend {
       info!("Session extension is not allowed by the gateway");
@@ -87,12 +90,16 @@ async fn run_session_runtime(session_ctx: SessionContext, mut session_info: Sess
           return;
         };
 
-        eprintln!("Session extended.");
+        report(log_format, Level::Info, "Session extended.");
         session_info = next_session_info;
       }
       Err(err) => {
         warn!("Failed to extend session: {}", err);
-        eprintln!("WARNING: Failed to extend session: {}", err);
+        report(
+          log_format,
+          Level::Warn,
+          &format!("WARNING: Failed to extend session: {}", err),
+        );
         return;
       }
     }

--- a/crates/gpapi/src/clap/mod.rs
+++ b/crates/gpapi/src/clap/mod.rs
@@ -1,7 +1,12 @@
-use clap_verbosity_flag::{LogLevel, Verbosity, VerbosityFilter};
-use log::{Level, error};
+use std::io::{self, Write};
 
-use crate::{error::PortalError, log_format::LogFormat};
+use clap_verbosity_flag::{LogLevel, Verbosity, VerbosityFilter};
+use log::Level;
+
+use crate::{
+  error::PortalError,
+  log_format::{LogFormat, write_json_record},
+};
 
 pub mod args;
 
@@ -54,20 +59,42 @@ fn retry_hints(err: &anyhow::Error, args: &impl Args) -> Vec<String> {
   hints
 }
 
+/// Render the failure as JSON records.
+///
+/// Written directly rather than through the `log` macros: this is the program's
+/// final report, not a log line, and it must survive `--quiet` exactly as the
+/// text form does. Going through the logger would let `-qqq` discard the only
+/// explanation of why the run failed.
+fn write_error_records<W: Write>(w: &mut W, err: &anyhow::Error, hints: &[String]) -> io::Result<()> {
+  let mut write_one = |message: &str| {
+    write_json_record(
+      w,
+      &log::Record::builder()
+        .level(Level::Error)
+        .target(module_path!())
+        .args(format_args!("{message}"))
+        .build(),
+    )
+  };
+
+  write_one(&format!("{err:?}"))?;
+
+  for hint in hints {
+    write_one(hint)?;
+  }
+
+  Ok(())
+}
+
 pub fn handle_error(err: anyhow::Error, args: &impl Args) {
   let hints = retry_hints(&err, args);
 
-  // In JSON mode this has to go through the logger like everything else:
-  // writing it straight to stderr would put a block of prose in the middle of
-  // a stream the caller is parsing a line at a time — and it would land on the
-  // record that explains the failure.
+  // In JSON mode the failure has to arrive as records too: a block of prose in
+  // the middle of the stream would break a caller parsing it a line at a time,
+  // and it would break on the record explaining the failure.
   if args.log_format() == LogFormat::Json {
-    error!("{err:?}");
-
-    for hint in hints {
-      error!("{hint}");
-    }
-
+    // Nothing useful to do if stderr itself is gone.
+    let _ = write_error_records(&mut io::stderr().lock(), &err, &hints);
     return;
   }
 
@@ -189,5 +216,26 @@ mod tests {
     let hints = retry_hints(&anyhow!("something else went wrong"), &TestArgs::default());
 
     assert!(hints.is_empty(), "got {hints:?}");
+  }
+
+  /// The failure is the program's final report, so in JSON mode it must be one
+  /// more record on the same stream — and it must not be filtered away, which
+  /// is why it does not go through the log macros. A run that fails silently is
+  /// worse than one that fails noisily.
+  #[test]
+  fn the_failure_is_reported_as_records() {
+    let hints = vec!["Re-run it with the `--ignore-tls-errors` option".to_string()];
+    let mut out = Vec::new();
+
+    write_error_records(&mut out, &anyhow!(PortalError::TlsError), &hints).expect("writing to a Vec cannot fail");
+
+    let out = String::from_utf8(out).expect("output should be UTF-8");
+    let lines: Vec<_> = out.lines().collect();
+    assert_eq!(lines.len(), 2, "expected the error and its hint: {out:?}");
+
+    for line in lines {
+      let v: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|e| panic!("not JSON: {line:?} ({e})"));
+      assert_eq!(v["level"], "ERROR");
+    }
   }
 }

--- a/crates/gpapi/src/clap/mod.rs
+++ b/crates/gpapi/src/clap/mod.rs
@@ -1,32 +1,80 @@
 use clap_verbosity_flag::{LogLevel, Verbosity, VerbosityFilter};
-use log::Level;
+use log::{Level, error};
 
-use crate::error::PortalError;
+use crate::{error::PortalError, log_format::LogFormat};
 
 pub mod args;
 
 pub trait Args {
   fn fix_openssl(&self) -> bool;
   fn ignore_tls_errors(&self) -> bool;
+
+  /// How this program renders its logs.
+  ///
+  /// Defaults to text so that a binary without the flag is unaffected.
+  fn log_format(&self) -> LogFormat {
+    LogFormat::Text
+  }
 }
 
-pub fn handle_error(err: anyhow::Error, args: &impl Args) {
-  eprintln!("\nError: {:?}", err);
-
+/// Suggestions for re-running the command, for failures that have a known
+/// workaround. Empty when there is nothing useful to say — including when the
+/// relevant option is already in use.
+fn retry_hints(err: &anyhow::Error, args: &impl Args) -> Vec<String> {
   let Some(err) = err.downcast_ref::<PortalError>() else {
-    return;
+    return Vec::new();
   };
 
+  let command_line = || {
+    let argv = std::env::args().collect::<Vec<_>>();
+    let program = argv.first().cloned().unwrap_or_default();
+    let rest = argv.get(1..).map(|rest| rest.join(" ")).unwrap_or_default();
+
+    (program, rest)
+  };
+
+  // The blank line between the sentence and the command is part of the output
+  // users already see; keep it exactly.
+  let mut hints = Vec::new();
+
   if err.is_legacy_openssl_error() && !args.fix_openssl() {
-    eprintln!("\nRe-run it with the `--fix-openssl` option to work around this issue, e.g.:\n");
-    let args = std::env::args().collect::<Vec<_>>();
-    eprintln!("{} --fix-openssl {}\n", args[0], args[1..].join(" "));
+    let (program, rest) = command_line();
+    hints.push(format!(
+      "Re-run it with the `--fix-openssl` option to work around this issue, e.g.:\n\n{program} --fix-openssl {rest}"
+    ));
   }
 
   if err.is_tls_error() && !args.ignore_tls_errors() {
-    eprintln!("\nRe-run it with the `--ignore-tls-errors` option to ignore the certificate error, e.g.:\n");
-    let args = std::env::args().collect::<Vec<_>>();
-    eprintln!("{} --ignore-tls-errors {}\n", args[0], args[1..].join(" "));
+    let (program, rest) = command_line();
+    hints.push(format!(
+      "Re-run it with the `--ignore-tls-errors` option to ignore the certificate error, e.g.:\n\n{program} --ignore-tls-errors {rest}"
+    ));
+  }
+
+  hints
+}
+
+pub fn handle_error(err: anyhow::Error, args: &impl Args) {
+  let hints = retry_hints(&err, args);
+
+  // In JSON mode this has to go through the logger like everything else:
+  // writing it straight to stderr would put a block of prose in the middle of
+  // a stream the caller is parsing a line at a time — and it would land on the
+  // record that explains the failure.
+  if args.log_format() == LogFormat::Json {
+    error!("{err:?}");
+
+    for hint in hints {
+      error!("{hint}");
+    }
+
+    return;
+  }
+
+  eprintln!("\nError: {err:?}");
+
+  for hint in hints {
+    eprintln!("\n{hint}\n");
   }
 }
 
@@ -77,5 +125,69 @@ impl ToVerboseArg for Level {
       Level::Debug => Some("-v"),
       Level::Trace => Some("-vv"),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use anyhow::anyhow;
+
+  use super::*;
+
+  #[derive(Default)]
+  struct TestArgs {
+    fix_openssl: bool,
+    ignore_tls_errors: bool,
+  }
+
+  impl Args for TestArgs {
+    fn fix_openssl(&self) -> bool {
+      self.fix_openssl
+    }
+
+    fn ignore_tls_errors(&self) -> bool {
+      self.ignore_tls_errors
+    }
+  }
+
+  /// A binary that never learned about the flag keeps its current output.
+  #[test]
+  fn log_format_defaults_to_text() {
+    assert_eq!(TestArgs::default().log_format(), LogFormat::Text);
+  }
+
+  #[test]
+  fn a_tls_failure_suggests_ignoring_tls_errors() {
+    let hints = retry_hints(&anyhow!(PortalError::TlsError), &TestArgs::default());
+
+    assert_eq!(hints.len(), 1, "expected one hint, got {hints:?}");
+    assert!(hints[0].contains("--ignore-tls-errors"), "got {:?}", hints[0]);
+    // The command sits on its own line after a blank one, as it always has.
+    assert!(
+      hints[0].contains("e.g.:\n\n"),
+      "blank line before the command: {:?}",
+      hints[0]
+    );
+  }
+
+  /// Suggesting an option the user already passed is noise, and in JSON mode it
+  /// would be an extra record on every failed run.
+  #[test]
+  fn no_hint_when_the_option_is_already_in_use() {
+    let args = TestArgs {
+      ignore_tls_errors: true,
+      ..Default::default()
+    };
+
+    assert!(retry_hints(&anyhow!(PortalError::TlsError), &args).is_empty());
+  }
+
+  /// Most failures have no known workaround; inventing advice for them would
+  /// mislead.
+  #[test]
+  fn no_hints_for_an_unrelated_error() {
+    let hints = retry_hints(&anyhow!("something else went wrong"), &TestArgs::default());
+
+    assert!(hints.is_empty(), "got {hints:?}");
   }
 }

--- a/crates/gpapi/src/clap/mod.rs
+++ b/crates/gpapi/src/clap/mod.rs
@@ -59,50 +59,81 @@ fn retry_hints(err: &anyhow::Error, args: &impl Args) -> Vec<String> {
   hints
 }
 
-/// Render the failure as JSON records.
+/// Write one message to `w` the way `format` asks for.
 ///
-/// Written directly rather than through the `log` macros: this is the program's
-/// final report, not a log line, and it must survive `--quiet` exactly as the
-/// text form does. Going through the logger would let `-qqq` discard the only
-/// explanation of why the run failed.
-fn write_error_records<W: Write>(w: &mut W, err: &anyhow::Error, hints: &[String]) -> io::Result<()> {
-  let mut write_one = |message: &str| {
-    write_json_record(
-      w,
-      &log::Record::builder()
-        .level(Level::Error)
-        .target(module_path!())
-        .args(format_args!("{message}"))
-        .build(),
-    )
-  };
+/// Text is emitted exactly as it always was, so existing output does not move.
+/// JSON is written directly rather than through the `log` macros, because these
+/// are reports rather than log lines: they must survive `--quiet`, which would
+/// otherwise discard the only explanation of a failed run.
+///
+/// The record is rendered into one buffer and written once. `serde_json`'s
+/// `Display` would otherwise reach the stream in dozens of fragments, and any
+/// process sharing this stderr — the spawned authenticator, a connect script —
+/// could land a line inside a half-written record.
+fn write_message<W: Write>(w: &mut W, format: LogFormat, level: Level, message: &str) -> io::Result<()> {
+  match format {
+    LogFormat::Text => writeln!(w, "{message}"),
+    LogFormat::Json => {
+      // Callers pass the exact text line, blank-line padding included, so the
+      // text form does not move. A record carries its own separation.
+      let message = message.trim_start_matches('\n');
+      let mut line = Vec::new();
 
-  write_one(&format!("{err:?}"))?;
+      write_json_record(
+        &mut line,
+        &log::Record::builder()
+          .level(level)
+          .target(module_path!())
+          .args(format_args!("{message}"))
+          .build(),
+      )?;
 
-  for hint in hints {
-    write_one(hint)?;
+      w.write_all(&line)
+    }
+  }
+}
+
+/// Report a user-facing line that is not a log record — a note, a warning, or
+/// advice about what to try next.
+///
+/// Callers used `eprintln!` directly, which in JSON mode drops prose into a
+/// stream the caller is parsing a line at a time. Routing them here keeps one
+/// answer to "how does this program emit a user-facing line", and leaves the
+/// text form byte-for-byte unchanged.
+pub fn report(format: LogFormat, level: Level, message: &str) {
+  let _ = write_message(&mut io::stderr().lock(), format, level, message);
+}
+
+fn write_failure<W: Write>(w: &mut W, format: LogFormat, err: &anyhow::Error, hints: &[String]) -> io::Result<()> {
+  match format {
+    LogFormat::Text => {
+      writeln!(w, "\nError: {err:?}")?;
+
+      for hint in hints {
+        writeln!(w, "\n{hint}\n")?;
+      }
+    }
+    LogFormat::Json => {
+      write_message(w, format, Level::Error, &format!("{err:?}"))?;
+
+      for hint in hints {
+        write_message(w, format, Level::Error, hint)?;
+      }
+    }
   }
 
   Ok(())
 }
 
-pub fn handle_error(err: anyhow::Error, args: &impl Args) {
+fn handle_error_to<W: Write>(w: &mut W, err: anyhow::Error, args: &impl Args) -> io::Result<()> {
   let hints = retry_hints(&err, args);
 
-  // In JSON mode the failure has to arrive as records too: a block of prose in
-  // the middle of the stream would break a caller parsing it a line at a time,
-  // and it would break on the record explaining the failure.
-  if args.log_format() == LogFormat::Json {
-    // Nothing useful to do if stderr itself is gone.
-    let _ = write_error_records(&mut io::stderr().lock(), &err, &hints);
-    return;
-  }
+  write_failure(w, args.log_format(), &err, &hints)
+}
 
-  eprintln!("\nError: {err:?}");
-
-  for hint in hints {
-    eprintln!("\n{hint}\n");
-  }
+pub fn handle_error(err: anyhow::Error, args: &impl Args) {
+  // Nothing useful to do if stderr itself is gone.
+  let _ = handle_error_to(&mut io::stderr().lock(), err, args);
 }
 
 #[derive(Debug)]
@@ -165,6 +196,7 @@ mod tests {
   struct TestArgs {
     fix_openssl: bool,
     ignore_tls_errors: bool,
+    log_format: LogFormat,
   }
 
   impl Args for TestArgs {
@@ -175,12 +207,48 @@ mod tests {
     fn ignore_tls_errors(&self) -> bool {
       self.ignore_tls_errors
     }
+
+    fn log_format(&self) -> LogFormat {
+      self.log_format
+    }
   }
 
   /// A binary that never learned about the flag keeps its current output.
   #[test]
   fn log_format_defaults_to_text() {
-    assert_eq!(TestArgs::default().log_format(), LogFormat::Text);
+    struct Bare;
+
+    impl Args for Bare {
+      fn fix_openssl(&self) -> bool {
+        false
+      }
+
+      fn ignore_tls_errors(&self) -> bool {
+        false
+      }
+    }
+
+    assert_eq!(Bare.log_format(), LogFormat::Text);
+  }
+
+  /// The seam that matters: `handle_error` must ask the args which format to
+  /// use. Testing the writer alone would leave a version that always reports as
+  /// prose passing every test.
+  #[test]
+  fn handle_error_honours_the_requested_format() {
+    let args = TestArgs {
+      log_format: LogFormat::Json,
+      ..Default::default()
+    };
+    let mut out = Vec::new();
+
+    handle_error_to(&mut out, anyhow!(PortalError::TlsError), &args).expect("writing to a Vec cannot fail");
+
+    let out = String::from_utf8(out).expect("output should be UTF-8");
+    for line in out.lines() {
+      serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|e| panic!("not JSON: {line:?} ({e})"));
+    }
+    assert!(!out.is_empty(), "the failure must be reported");
   }
 
   #[test]
@@ -218,18 +286,22 @@ mod tests {
     assert!(hints.is_empty(), "got {hints:?}");
   }
 
+  fn failure_output(format: LogFormat) -> String {
+    let hints = vec!["Re-run it with the `--ignore-tls-errors` option".to_string()];
+    let mut out = Vec::new();
+
+    write_failure(&mut out, format, &anyhow!(PortalError::TlsError), &hints).expect("writing to a Vec cannot fail");
+
+    String::from_utf8(out).expect("output should be UTF-8")
+  }
+
   /// The failure is the program's final report, so in JSON mode it must be one
   /// more record on the same stream — and it must not be filtered away, which
   /// is why it does not go through the log macros. A run that fails silently is
   /// worse than one that fails noisily.
   #[test]
   fn the_failure_is_reported_as_records() {
-    let hints = vec!["Re-run it with the `--ignore-tls-errors` option".to_string()];
-    let mut out = Vec::new();
-
-    write_error_records(&mut out, &anyhow!(PortalError::TlsError), &hints).expect("writing to a Vec cannot fail");
-
-    let out = String::from_utf8(out).expect("output should be UTF-8");
+    let out = failure_output(LogFormat::Json);
     let lines: Vec<_> = out.lines().collect();
     assert_eq!(lines.len(), 2, "expected the error and its hint: {out:?}");
 
@@ -237,5 +309,23 @@ mod tests {
       let v: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|e| panic!("not JSON: {line:?} ({e})"));
       assert_eq!(v["level"], "ERROR");
     }
+  }
+
+  /// The format has to be honoured, not merely available: reporting the failure
+  /// as prose to a caller that asked for JSON is the defect this whole flag
+  /// exists to remove.
+  #[test]
+  fn the_format_decides_how_the_failure_is_written() {
+    assert!(
+      serde_json::from_str::<serde_json::Value>(failure_output(LogFormat::Json).lines().next().unwrap()).is_ok(),
+      "json mode must not emit prose"
+    );
+
+    let text = failure_output(LogFormat::Text);
+    assert!(text.starts_with("\nError: "), "text mode keeps its shape: {text:?}");
+    assert!(
+      serde_json::from_str::<serde_json::Value>(text.trim()).is_err(),
+      "text mode must not emit JSON: {text:?}"
+    );
   }
 }

--- a/crates/gpapi/src/clap/mod.rs
+++ b/crates/gpapi/src/clap/mod.rs
@@ -16,10 +16,10 @@ pub trait Args {
 
   /// How this program renders its logs.
   ///
-  /// Defaults to text so that a binary without the flag is unaffected.
-  fn log_format(&self) -> LogFormat {
-    LogFormat::Text
-  }
+  /// Required rather than defaulted: a default would let an implementor drop
+  /// the override and silently report failures as prose to a caller that asked
+  /// for JSON, with nothing — not even a warning — to catch it.
+  fn log_format(&self) -> LogFormat;
 }
 
 /// Suggestions for re-running the command, for failures that have a known
@@ -211,24 +211,6 @@ mod tests {
     fn log_format(&self) -> LogFormat {
       self.log_format
     }
-  }
-
-  /// A binary that never learned about the flag keeps its current output.
-  #[test]
-  fn log_format_defaults_to_text() {
-    struct Bare;
-
-    impl Args for Bare {
-      fn fix_openssl(&self) -> bool {
-        false
-      }
-
-      fn ignore_tls_errors(&self) -> bool {
-        false
-      }
-    }
-
-    assert_eq!(Bare.log_format(), LogFormat::Text);
   }
 
   /// The seam that matters: `handle_error` must ask the args which format to

--- a/crates/gpapi/src/lib.rs
+++ b/crates/gpapi/src/lib.rs
@@ -4,6 +4,7 @@ pub mod credential;
 pub mod error;
 pub mod gateway;
 pub mod gp_params;
+pub mod log_format;
 pub mod os_profile;
 pub mod params;
 pub mod portal;

--- a/crates/gpapi/src/log_format.rs
+++ b/crates/gpapi/src/log_format.rs
@@ -1,0 +1,164 @@
+//! Machine-readable log output.
+//!
+//! The default human format is fine at a terminal, but tools that drive
+//! gpclient headless have to parse it — and end up matching on prose, including
+//! text that comes from dependencies rather than from this project. JSON lines
+//! give those callers fields instead.
+//!
+//! This module deliberately depends only on `log` and `serde_json`, so every
+//! binary can use it without pulling in a logging backend, and so the rendering
+//! can be tested without installing a global logger.
+
+use std::io::{self, Write};
+
+use chrono::{SecondsFormat, Utc};
+use serde_json::json;
+
+/// How log records are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum LogFormat {
+  /// The human-readable default.
+  #[default]
+  Text,
+  /// One JSON object per line.
+  Json,
+}
+
+impl LogFormat {
+  /// The name this format is known by on a command line.
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      Self::Text => "text",
+      Self::Json => "json",
+    }
+  }
+}
+
+/// Write a [`log::Record`] to `w` as one JSON line, newline included.
+///
+/// This is the form a logging backend needs, and it writes into the buffer the
+/// backend already handed us rather than allocating a line to be copied. It
+/// takes a `Record` and a `Write` rather than any backend's own types, so `log`
+/// stays the only logging dependency here — with `env_logger`, this function
+/// *is* the format callback:
+///
+/// ```ignore
+/// // Not compiled as a doctest: env_logger is an optional dependency of this
+/// // crate, so it is not linked when the docs are built.
+/// env_logger::builder().format(write_json_record).init();
+/// ```
+pub fn write_json_record<W: Write>(w: &mut W, record: &log::Record) -> io::Result<()> {
+  writeln!(
+    w,
+    "{}",
+    json!({
+      "timestamp": Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+      "level": record.level().as_str(),
+      "target": record.target(),
+      "message": record.args().to_string(),
+    })
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use chrono::{DateTime, SubsecRound};
+  use log::Level;
+
+  use super::*;
+
+  fn parse(line: &str) -> serde_json::Value {
+    serde_json::from_str(line).expect("each line must be valid JSON")
+  }
+
+  fn write_record(record: &log::Record) -> String {
+    let mut buf = Vec::new();
+    write_json_record(&mut buf, record).expect("writing to a Vec cannot fail");
+    String::from_utf8(buf).expect("output should be UTF-8")
+  }
+
+  /// The fields a consumer is promised, taken off a `Record` as a backend
+  /// hands it over.
+  #[test]
+  fn record_renders_the_expected_fields() {
+    // Built inline: `format_args!` borrows its arguments for the statement it
+    // appears in, so a `Record` held in a `let` would outlive them.
+    let v = parse(&write_record(
+      &log::Record::builder()
+        .level(Level::Error)
+        .target("gpclient::connect")
+        .args(format_args!("portal {} unreachable", "vpn.example.com"))
+        .build(),
+    ));
+
+    assert_eq!(v["level"], "ERROR");
+    assert_eq!(v["target"], "gpclient::connect");
+    assert_eq!(v["message"], "portal vpn.example.com unreachable");
+  }
+
+  /// Without a timestamp the JSON output would be strictly less informative
+  /// than the text format it replaces, and a consumer could not order or
+  /// correlate events.
+  #[test]
+  fn records_carry_a_utc_timestamp() {
+    let before = Utc::now();
+    let v = parse(&write_record(
+      &log::Record::builder()
+        .level(Level::Info)
+        .target("t")
+        .args(format_args!("connected"))
+        .build(),
+    ));
+    let after = Utc::now();
+
+    let ts = v["timestamp"].as_str().expect("timestamp must be a string");
+    let parsed = DateTime::parse_from_rfc3339(ts)
+      .unwrap_or_else(|e| panic!("timestamp must be RFC 3339: {ts:?} ({e})"))
+      .with_timezone(&Utc);
+
+    assert!(ts.ends_with('Z'), "timestamp must be UTC, got {ts:?}");
+    assert!(
+      parsed >= before.trunc_subsecs(3) && parsed <= after,
+      "timestamp {parsed} should be between {before} and {after}"
+    );
+  }
+
+  /// The backend appends records to one stream, so each has to terminate its
+  /// own line — exactly one, or the next record joins this one. A message
+  /// containing a newline must be escaped into the JSON string rather than
+  /// splitting the record in two.
+  #[test]
+  fn record_ends_with_a_single_newline() {
+    let out = write_record(
+      &log::Record::builder()
+        .level(Level::Info)
+        .target("t")
+        .args(format_args!("first\nsecond"))
+        .build(),
+    );
+
+    assert!(out.ends_with('\n'), "record must terminate its line: {out:?}");
+    assert_eq!(out.matches('\n').count(), 1, "record must be one line: {out:?}");
+    assert_eq!(parse(&out)["message"], "first\nsecond", "the newline must survive");
+  }
+
+  /// `as_str` is what gets passed to a child process on the command line, and
+  /// clap parses that with the names from its own `ValueEnum` derive. If the
+  /// two ever disagree, gpclient hands gpauth a value gpauth rejects.
+  #[cfg(feature = "clap")]
+  #[test]
+  fn as_str_agrees_with_the_names_clap_parses() {
+    use clap::ValueEnum;
+
+    for format in [LogFormat::Text, LogFormat::Json] {
+      let clap_name = format
+        .to_possible_value()
+        .expect("every variant is selectable")
+        .get_name()
+        .to_owned();
+
+      assert_eq!(format.as_str(), clap_name);
+    }
+  }
+}

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, process::Stdio};
+use std::{
+  path::{Path, PathBuf},
+  process::Stdio,
+};
 
 use anyhow::bail;
 use common::binary_paths;
@@ -152,7 +155,7 @@ impl<'a> SamlAuthLauncher<'a> {
   /// Split out from `launch` so a test can observe the argv the child actually
   /// receives: asserting on the builder's own fields would not catch an
   /// argument that never gets appended.
-  fn build_command(&self, program: &PathBuf) -> Command {
+  fn build_command(&self, program: &Path) -> Command {
     let mut auth_cmd = Command::new(program);
     auth_cmd.arg(self.server);
 
@@ -288,7 +291,7 @@ mod tests {
 
   fn child_args(launcher: SamlAuthLauncher) -> Vec<String> {
     launcher
-      .build_command(&PathBuf::from("gpauth"))
+      .build_command(Path::new("gpauth"))
       .as_std()
       .get_args()
       .map(|arg| arg.to_string_lossy().into_owned())

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 use common::binary_paths;
 use tokio::process::Command;
 
-use crate::{auth::SamlAuthResult, credential::Credential, os_profile::OsProfile};
+use crate::{auth::SamlAuthResult, credential::Credential, log_format::LogFormat, os_profile::OsProfile};
 
 use super::command_traits::CommandExt;
 
@@ -29,6 +29,7 @@ pub struct SamlAuthLauncher<'a> {
   default_browser: bool,
   browser: Option<&'a str>,
   verbose: Option<&'a str>,
+  log_format: Option<LogFormat>,
 }
 
 impl<'a> SamlAuthLauncher<'a> {
@@ -54,6 +55,7 @@ impl<'a> SamlAuthLauncher<'a> {
       default_browser: false,
       browser: None,
       verbose: None,
+      log_format: None,
     }
   }
 
@@ -127,18 +129,31 @@ impl<'a> SamlAuthLauncher<'a> {
     self
   }
 
+  /// Render the child's logs the same way as ours.
+  ///
+  /// gpauth inherits this process's stderr, so leaving it on the default would
+  /// interleave text records into an otherwise machine-readable stream.
+  ///
+  /// The default format is deliberately *not* forwarded: a gpauth predating the
+  /// flag rejects it as an unknown argument, and someone who never asked for
+  /// JSON should not need matching binaries.
+  pub fn log_format(mut self, log_format: LogFormat) -> Self {
+    self.log_format = (log_format != LogFormat::Text).then_some(log_format);
+    self
+  }
+
   pub fn verbose(mut self, verbose: Option<&'a str>) -> Self {
     self.verbose = verbose;
     self
   }
 
-  /// Launch the authenticator binary as the current user or SUDO_USER if available.
-  pub async fn launch(self) -> anyhow::Result<Credential> {
-    let program = self
-      .auth_executable
-      .map(PathBuf::from)
-      .unwrap_or_else(binary_paths::gpauth);
-    let mut auth_cmd = Command::new(&program);
+  /// The command line this launcher will run.
+  ///
+  /// Split out from `launch` so a test can observe the argv the child actually
+  /// receives: asserting on the builder's own fields would not catch an
+  /// argument that never gets appended.
+  fn build_command(&self, program: &PathBuf) -> Command {
+    let mut auth_cmd = Command::new(program);
     auth_cmd.arg(self.server);
 
     if self.gateway {
@@ -200,9 +215,24 @@ impl<'a> SamlAuthLauncher<'a> {
       auth_cmd.arg("--browser").arg(browser);
     }
 
+    if let Some(log_format) = self.log_format {
+      auth_cmd.arg("--log-format").arg(log_format.as_str());
+    }
+
     if let Some(verbose) = self.verbose {
       auth_cmd.arg(verbose);
     }
+
+    auth_cmd
+  }
+
+  /// Launch the authenticator binary as the current user or SUDO_USER if available.
+  pub async fn launch(self) -> anyhow::Result<Credential> {
+    let program = self
+      .auth_executable
+      .map(PathBuf::from)
+      .unwrap_or_else(binary_paths::gpauth);
+    let auth_cmd = self.build_command(&program);
 
     let mut non_root_cmd = auth_cmd.into_non_root()?;
     let child = non_root_cmd.kill_on_drop(true).stdout(Stdio::piped()).spawn();
@@ -254,6 +284,47 @@ mod tests {
     let launcher = SamlAuthLauncher::new("portal.example.com").os_profile(&profile);
 
     assert_eq!(launcher.client_version, Some("6.0.0"));
+  }
+
+  fn child_args(launcher: SamlAuthLauncher) -> Vec<String> {
+    launcher
+      .build_command(&PathBuf::from("gpauth"))
+      .as_std()
+      .get_args()
+      .map(|arg| arg.to_string_lossy().into_owned())
+      .collect()
+  }
+
+  /// gpauth writes to the same stderr as its parent, so a caller reading the
+  /// parent's JSON would hit gpauth's text records mid-stream unless the format
+  /// is passed down.
+  #[test]
+  fn json_is_forwarded_to_the_child() {
+    let args = child_args(SamlAuthLauncher::new("portal.example.com").log_format(LogFormat::Json));
+
+    assert!(
+      args.windows(2).any(|pair| pair == ["--log-format", "json"]),
+      "expected --log-format json in {args:?}"
+    );
+  }
+
+  /// A gpauth predating the flag rejects it outright — clap treats an unknown
+  /// argument as an error — so a caller who never asked for JSON must produce
+  /// exactly the argv it produced before, or mismatched binaries stop working
+  /// for people not using this feature at all.
+  #[test]
+  fn the_default_format_never_reaches_the_child() {
+    for launcher in [
+      SamlAuthLauncher::new("portal.example.com").log_format(LogFormat::Text),
+      SamlAuthLauncher::new("portal.example.com"),
+    ] {
+      let args = child_args(launcher);
+
+      assert!(
+        !args.iter().any(|arg| arg == "--log-format"),
+        "unexpected flag in {args:?}"
+      );
+    }
   }
 
   #[test]

--- a/crates/gpapi/src/process/auth_launcher.rs
+++ b/crates/gpapi/src/process/auth_launcher.rs
@@ -32,7 +32,7 @@ pub struct SamlAuthLauncher<'a> {
   default_browser: bool,
   browser: Option<&'a str>,
   verbose: Option<&'a str>,
-  log_format: Option<LogFormat>,
+  log_format: LogFormat,
 }
 
 impl<'a> SamlAuthLauncher<'a> {
@@ -58,7 +58,7 @@ impl<'a> SamlAuthLauncher<'a> {
       default_browser: false,
       browser: None,
       verbose: None,
-      log_format: None,
+      log_format: LogFormat::Text,
     }
   }
 
@@ -134,14 +134,10 @@ impl<'a> SamlAuthLauncher<'a> {
 
   /// Render the child's logs the same way as ours.
   ///
-  /// gpauth inherits this process's stderr, so leaving it on the default would
-  /// interleave text records into an otherwise machine-readable stream.
-  ///
-  /// The default format is deliberately *not* forwarded: a gpauth predating the
-  /// flag rejects it as an unknown argument, and someone who never asked for
-  /// JSON should not need matching binaries.
+  /// gpauth inherits this process's stderr, so both processes must use the same
+  /// format to keep the stream consistent.
   pub fn log_format(mut self, log_format: LogFormat) -> Self {
-    self.log_format = (log_format != LogFormat::Text).then_some(log_format);
+    self.log_format = log_format;
     self
   }
 
@@ -218,9 +214,7 @@ impl<'a> SamlAuthLauncher<'a> {
       auth_cmd.arg("--browser").arg(browser);
     }
 
-    if let Some(log_format) = self.log_format {
-      auth_cmd.arg("--log-format").arg(log_format.as_str());
-    }
+    auth_cmd.arg("--log-format").arg(self.log_format.as_str());
 
     if let Some(verbose) = self.verbose {
       auth_cmd.arg(verbose);
@@ -311,12 +305,10 @@ mod tests {
     );
   }
 
-  /// A gpauth predating the flag rejects it outright — clap treats an unknown
-  /// argument as an error — so a caller who never asked for JSON must produce
-  /// exactly the argv it produced before, or mismatched binaries stop working
-  /// for people not using this feature at all.
+  /// The launcher always passes the selected format so the parent and child
+  /// cannot silently drift onto different output formats.
   #[test]
-  fn the_default_format_never_reaches_the_child() {
+  fn text_is_forwarded_to_the_child() {
     for launcher in [
       SamlAuthLauncher::new("portal.example.com").log_format(LogFormat::Text),
       SamlAuthLauncher::new("portal.example.com"),
@@ -324,8 +316,8 @@ mod tests {
       let args = child_args(launcher);
 
       assert!(
-        !args.iter().any(|arg| arg == "--log-format"),
-        "unexpected flag in {args:?}"
+        args.windows(2).any(|pair| pair == ["--log-format", "text"]),
+        "expected --log-format text in {args:?}"
       );
     }
   }


### PR DESCRIPTION
## Why

Programs that drive `gpclient` headless have to parse its human-readable log output — matching on prose, including text that originates in dependencies rather than in this project. A message reworded upstream then silently breaks the caller.

This adds `--log-format json` to `gpclient` and `gpauth`: one JSON object per record, so callers match on fields instead. Text remains the default and the text path never touches `env_logger`'s formatter, so existing output is unchanged.

```
$ gpclient --log-format json connect no-such-portal.invalid
{"level":"INFO","message":"gpclient started: 2.6.5","target":"gpclient::cli","timestamp":"2026-08-12T17:43:39.613Z"}
{"level":"WARN","message":"Failed to connect portal with prelogin: error sending request for url (...)","target":"gpclient::connect","timestamp":"2026-08-12T17:43:39.695Z"}
{"level":"ERROR","message":"error sending request for url (...)\n\nCaused by:\n    0: client error (Connect)","target":"gpapi::clap","timestamp":"2026-08-12T17:43:39.695Z"}
```

## Two paths beyond the flag

Both are needed for the stream to be parseable end to end, and both are worth your scrutiny:

- **`handle_error` wrote the terminal error to stderr with `eprintln!`.** In JSON mode that put a block of prose in the middle of the stream, on the very record explaining why the run failed. It is now written as records instead — directly rather than through the `log` macros, so `--quiet` cannot discard the only explanation of a failed run. Its retry suggestions moved into a testable function; the text output is unchanged, verified against a real certificate failure.
- **`gpclient` forwards the format to the `gpauth` it spawns**, which inherits the same stderr and would otherwise interleave text records. Only a non-default format is forwarded — a `gpauth` predating the flag rejects it as an unknown argument, so mismatched binaries keep working for anyone not using JSON.
- **Four other places wrote prose straight to stderr** (the gateway recommendation, the missing-private-key advice, the session warnings). They now go through one `report` helper. Text output is unchanged; converting them to `log` macros instead would have prefixed a timestamp and level.

`openconnect`'s own progress messages already route through `log` via `ffi/vpn.c` → `vpn_log`, so they need no change.

## What json mode does not cover

`inquire` renders its prompts to stderr with terminal escapes, so a run that asks for a password, selects a gateway or answers MFA has non-JSON on the stream. That is a property of interactive use, not something the format can fix, so the flag's help text says so. json mode is aimed at non-interactive runs — where, as far as I can find, every line is now a record.

Also still prose on stderr, and outside what this touches: clap's own argument errors, and panic messages.

## Notes

- Keys serialise alphabetically (`serde_json::Map` is a `BTreeMap` here).
- Each record is written with a single `write_all`; gpauth inherits this stderr, so a fragmented write could be split by the child.
- No new dependencies; `Cargo.lock` is unchanged.
- The README hunk also picks up pre-existing drift — the `hip` command, `-v`/`-q`, and a stale `--fix-openssl` description — since it regenerates the block from `--help`.
- No changelog entry: the file has no `Unreleased` section and its entries link an issue, so that seemed yours to write.

## Testing

Verified in this repo's devcontainer on the pinned Rust 1.89.0 with `--locked`: `gpapi` 227, `gpclient` 55, `gpauth --no-default-features` 10, `cargo fmt --all -- --check` clean, no new clippy warnings.

The CLI tests drive a real `env_logger` through a pipe and assert on what it emits rather than how it was configured — `init_logger` became `build_logger`, returning the builder instead of installing it, to make that possible. Command assembly is likewise split out of `launch()` so the forwarding test asserts on the child's actual argv.

Happy to split the `handle_error` and `auth_launcher` changes into their own PR if you'd rather review the flag alone.
