### PR TITLE
feat(gpclient): add --cookie-only to print gateway cookie without starting tunnel

### DIFF
--- a/apps/gpclient/src/connect/args.rs
+++ b/apps/gpclient/src/connect/args.rs
@@ -146,6 +146,14 @@ pub(crate) struct ConnectArgs {
     num_args=0..=1
   )]
   pub(super) browser: Option<String>,
+
+  #[arg(
+    long,
+    help = "Authenticate and print the gateway cookie to stdout, then exit without starting the \
+            VPN tunnel. Outputs two lines: COOKIE='<value>' and HOST='<gateway>'. Combine with \
+            --cookie-cache to avoid re-authenticating when the portal session is still valid."
+  )]
+  pub(super) cookie_only: bool,
 }
 
 pub(super) fn build_os_profile(args: &ConnectArgs) -> OsProfile {
@@ -397,5 +405,25 @@ mod tests {
       Err(err) => err,
     };
     assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+  }
+
+  #[test]
+  fn cookie_only_flag_parses() {
+    use clap::Parser;
+
+    let cli = ConnectArgsTestCli::try_parse_from(["test", "portal.example.com", "--cookie-only"])
+      .expect("--cookie-only should parse");
+
+    assert!(cli.args.cookie_only);
+  }
+
+  #[test]
+  fn cookie_only_is_disabled_by_default() {
+    use clap::Parser;
+
+    let cli = ConnectArgsTestCli::try_parse_from(["test", "portal.example.com"])
+      .expect("connect args should parse");
+
+    assert!(!cli.args.cookie_only);
   }
 }

--- a/apps/gpclient/src/connect/gateway.rs
+++ b/apps/gpclient/src/connect/gateway.rs
@@ -341,6 +341,16 @@ impl ConnectHandler<'_> {
     allow_extend_session: bool,
     extension_auth: SessionExtensionAuth,
   ) -> Result<(), GatewayConnectError> {
+    // --cookie-only: print the gateway cookie and exit without opening a tunnel.
+    // No tun device is allocated, no root is required, and no logout is issued
+    // against the gateway — the cookie remains valid for subsequent use.
+    // Output format matches openconnect --authenticate for easy shell consumption.
+    if self.args.cookie_only {
+      println!("COOKIE='{}'", cookie);
+      println!("HOST='{}'", gateway);
+      return Ok(());
+    }
+
     let mtu = self.args.mtu.unwrap_or(0);
     let (hip, csd_wrapper) = self.determine_hip_script();
     let hip_user = self.determine_hip_user();


### PR DESCRIPTION
# feat(gpclient): add `--cookie-only` to print gateway cookie without starting tunnel

## Summary

Adds `--cookie-only` to `gpclient connect`. When set, the command authenticates
fully (including CAS/SAML, `--cookie-cache` reuse) then prints the gateway
authcookie to stdout and exits — without opening a tun device, without issuing
logout, and without requiring root.

## Motivation

There is currently no way to obtain a verified gateway authcookie from `gpclient`
without also starting the VPN tunnel (which requires root). External integrations
that need the cookie but want to manage the tunnel themselves — NetworkManager
plugins, systemd scripts, CI pipelines — have no clean path.

The existing `gpauth | gpclient --cookie-on-stdin` pattern produces a *portal*
`SamlAuthResult` (pre-gateway-login). What external integrations need is a
*gateway* authcookie (post-gateway-login, ready for `openconnect --cookie-on-stdin`).
`--cookie-only` fills that gap.

## Output format

Matches `openconnect --authenticate` for easy shell consumption and `eval` safety:

```
COOKIE='authcookie=…&portal=…&user=…&computer=…'
HOST='gateway.example.com'
```

## Relation to existing flags

| Flag | Input/Output | Level |
|---|---|---|
| `--cookie-on-stdin` | reads JSON `SamlAuthResult` | portal (pre-gateway-login) |
| `--cookie-only` | writes gateway authcookie | gateway (post-gateway-login) |

Together they cover both directions of external integration.

## Properties

- No tun device allocated → no root required
- No `logout.esp` issued → cookie stays valid for the caller
- Covers all three call sites in `connect_gateway()`: cached portal cookie,
  portal fallback, and gateway prelogin paths

## Usage examples

**Feed directly to openconnect:**
```bash
eval "$(gpclient connect portal.example.com \
    --browser --cookie-cache --cookie-only)"
printf '%s\n' "$COOKIE" | \
    sudo openconnect --protocol=gp --cookie-on-stdin portal.example.com
```

**Unprivileged auth + privileged tunnel (split across users/processes):**
```bash
# As normal user — no root required
RESULT=$(gpclient connect portal.example.com \
    --browser chrome \
    --cookie-cache ~/.config/gpclient/cookie.json \
    --cookie-only)

# As root / NM service — consume the cookie
printf '%s\n' "$(echo "$RESULT" | grep '^COOKIE=' | cut -d= -f2-)" | \
    openconnect --protocol=gp --cookie-on-stdin portal.example.com
```

**Combined with `--cookie-cache` for session reuse (browser only opens when
the portal session has expired):**
```bash
gpclient connect portal.example.com \
    --browser chrome \
    --cookie-cache \
    --cookie-only
```

## Changes

- `apps/gpclient/src/connect/args.rs` — add `cookie_only: bool` field with
  `--cookie-only` clap argument; add 2 tests
- `apps/gpclient/src/connect/gateway.rs` — early-return block at top of
  `connect_gateway()` covering all call sites

## Testing

```
cargo test -p gpclient --no-default-features -- connect::args
```

17 tests pass including the two new ones:
- `cookie_only_flag_parses` — verifies `--cookie-only` is accepted by clap
- `cookie_only_is_disabled_by_default` — verifies the flag defaults to false
